### PR TITLE
Realted-Bug:#1487468

### DIFF
--- a/webroot/common/ui/js/controller.app.js
+++ b/webroot/common/ui/js/controller.app.js
@@ -20,7 +20,19 @@ require.config({
         'controller-init': ctBaseDir + '/common/ui/js/controller.init',
 
         'lls-grid-config': ctBaseDir + '/config/linklocalservices/ui/js/linkLocalServices.grid.config',
-        'lls-parsers': ctBaseDir + '/config/linklocalservices/ui/js/linkLocalServices.parsers'
+        'lls-parsers': ctBaseDir + '/config/linklocalservices/ui/js/linkLocalServices.parsers',
+        'monitor-infra-confignode-model' :
+            'monitor/infrastructure/common/ui/js/models/'+
+            'ConfigNodeListModel',
+        'monitor-infra-analyticsnode-model' :
+            'monitor/infrastructure/common/ui/js/models/' +
+            'AnalyticsNodeListModel',
+        'monitor-infra-databasenode-model' :
+            'monitor/infrastructure/common/ui/js/models/' +
+            'DatabaseNodeListModel',
+        'monitor-infra-controlnode-model' :
+            'monitor/infrastructure/common/ui/js/models/' +
+            'ControlNodeListModel'
     },
     waitSeconds: 0
 });

--- a/webroot/common/ui/js/controller.constants.js
+++ b/webroot/common/ui/js/controller.constants.js
@@ -142,9 +142,13 @@ define([
 
         this.TOP_IN_LAST_MINS = 10;
         this.NUM_DATA_POINTS_FOR_FLOW_SERIES = 120;
-
+        this.COLOR_SEVERITY_MAP = {
+             red : 'error',
+             orange : 'warning',
+             blue : 'default',
+             green : 'okay'
+        };
         this.LINK_CONNECTOR_STRING = " --- ";
-
         this.getProjectsURL = function (domain) {
             //If the role is admin then we will display all the projects else the projects which has access
             var url = '/api/tenants/projects/' + domain,

--- a/webroot/common/ui/js/controller.labels.js
+++ b/webroot/common/ui/js/controller.labels.js
@@ -315,6 +315,110 @@ define([
         this.TITLE_ALARM_HISTORY = 'Alarm History';
         this.TITLE_ALARM_DETAILS = 'Alarm Details';
 
+        //Monitor Infra common
+        this.MONITOR_INFRA_VIEW_PATH =
+            'monitor/infrastructure/common/ui/js/views/';
+
+        //Config node labels
+        this.CONFIGNODE_VIEWPATH_PREFIX =
+            'monitor/infrastructure/confignode/ui/js/views/';
+        this.CONFIGNODE_SUMMARY_PAGE_ID = 'monitor-config-nodes';
+        this.CONFIGNODE_SUMMARY_URL =
+            '/api/admin/monitor/infrastructure/confignodes/summary';
+        this.CONFIGNODE_SUMMARY_TITLE = 'Config Nodes';
+        this.CONFIGNODE_SUMMARY_GRID_ID = 'config-nodes-grid';
+        this.CONFIGNODE_SUMMARY_SCATTERCHART_ID = 'config-nodes-scatterchart';
+        this.CONFIGNODE_SUMMARY_GRID_SECTION_ID = "config-nodes-grid-section";
+        this.CONFIGNODE_SUMMARY_CHART_ID = 'config-nodes-chart';
+        this.CONFIGNODE_SUMMARY_LIST_SECTION_ID = 'config-nodes-list-section';
+        this.CONFIGNODE_SUMMARY_SCATTERCHART_SECTION_ID =
+            'config-nodes-scatterchart-section';
+        this.CONFIGNODE_DETAILS_PAGE_ID = 'config_nodes_details_pages';
+        this.CONFIGNODE_TAB_SECTION_ID = 'config_node_tab_section';
+        this.CONFIGNODE_TAB_VIEW_ID = 'config_node_tab';
+        this.CONFIGNODE_DETAILS_SECTION_ID = 'config_node_details_section';
+        this.CONFIGNODE_TABS_ID = 'config_node_tab'
+        this.CACHE_CONFIGNODE = 'cache-config-nodes';
+
+        //Control node labels
+        this.CONTROLNODE_VIEWPATH_PREFIX =
+            'monitor/infrastructure/controlnode/ui/js/views/';
+        this.CONTROLNODE_SUMMARY_PAGE_ID = 'monitor-control-nodes';
+        this.CONTROLNODE_SUMMARY_URL =
+            '/api/admin/monitor/infrastructure/controlnodes/summary';
+        this.CONTROLNODE_SUMMARY_TITLE = 'Control Nodes';
+        this.CONTROLNODE_SUMMARY_GRID_ID = 'control-nodes-grid';
+        this.CONTROLNODE_SUMMARY_SCATTERCHART_ID = 'control-nodes-scatterchart';
+        this.CONTROLNODE_SUMMARY_GRID_SECTION_ID = "control-nodes-grid-section";
+        this.CONTROLNODE_SUMMARY_CHART_ID = 'control-nodes-chart';
+        this.CONTROLNODE_SUMMARY_LIST_SECTION_ID = 'control-nodes-list-section';
+        this.CONTROLNODE_SUMMARY_SCATTERCHART_SECTION_ID =
+            'control-nodes-scatterchart-section';
+        this.CACHE_CONTROLNODE = 'cache-control-nodes';
+        this.CONTROLNODE_DETAILS_PAGE_ID = 'control_nodes_details';
+        this.CONTROLNODE_DETAIL_PAGE_ID = 'control_nodes_detail_page'
+        this.CONTROLNDOE_DETAILS_SECTION_ID = 'control_nodes_details_section';
+        this.CONTROLNODE_TAB_SECTION_ID = 'control_nodes_tab_section';
+        this.CONTROLNODE_TAB_VIEW_ID = 'control_nodes_tab_view';
+        this.CONTROLNODE_DETAILS_TABS_ID = 'control_nodes_details-tab';
+        this.CONTROLNODE_PEERS_GRID_SECTION_ID = 'control_node_peers_grid_section_id';
+        this.CONTROLNODE_PEERS_GRID_VIEW_ID = 'controlnode_peers_id';
+        this.CONTROLNODE_PEERS_GRID_ID = "control_node_peers_grid_id";
+        this.CONTROLNODE_PEERS_TITLE = "Peers";
+
+        //Database node labels
+        this.DATABASENODE_VIEWPATH_PREFIX =
+            'monitor/infrastructure/databasenode/ui/js/views/';
+        this.DATABASENODE_SUMMARY_PAGE_ID = 'monitor-database-nodes';
+        this.DATABASENODE_SUMMARY_URL =
+            '/api/admin/monitor/infrastructure/dbnodes/summary';
+        this.DATABASENODE_SUMMARY_TITLE = 'Database Nodes';
+        this.DATABASENODE_SUMMARY_GRID_ID = 'database-nodes-grid';
+        this.DATABASENODE_SUMMARY_SCATTERCHART_ID =
+            'database-nodes-scatterchart';
+        this.DATABASENODE_SUMMARY_GRID_SECTION_ID =
+            "database-nodes-grid-section";
+        this.DATABASENODE_SUMMARY_CHART_ID = 'database-nodes-chart';
+        this.DATABASENODE_SUMMARY_LIST_SECTION_ID =
+            'database-nodes-list-section';
+        this.DATABASENODE_SUMMARY_SCATTERCHART_SECTION_ID =
+            'database-nodes-scatterchart-section';
+        this.DATABASENODE_DETAILS_PAGE_ID = 'database_nodes_details_pages';
+        this.DATABASENODE_TAB_SECTION_ID = 'database_node_tab_section';
+        this.DATABASENODE_TAB_VIEW_ID = 'database_node_tab';
+        this.DATABASENODE_DETAILS_SECTION_ID = 'database_node_details_section';
+        this.DATABASENODE_TABS_ID = 'database_node_tabs';
+        this.CACHE_DATABASENODE = 'cache-database-nodes';
+
+        //Analytics node labels
+        this.ANALYTICSNODE_VIEWPATH_PREFIX =
+            'monitor/infrastructure/analyticsnode/ui/js/views/';
+        this.ANALYTICSNODE_SUMMARY_PAGE_ID = 'monitor-analytics-nodes';
+        this.ANALYTICSNODE_SUMMARY_URL =
+            '/api/admin/monitor/infrastructure/analyticsnodes/summary';
+        this.ANALYTICSNODE_SUMMARY_TITLE = 'Analytics Nodes';
+        this.ANALYTICSNODE_SUMMARY_GRID_ID = 'analytics-nodes-grid';
+        this.ANALYTICSNODE_SUMMARY_SCATTERCHART_ID =
+            'analytics-nodes-scatterchart';
+        this.ANALYTICSNODE_SUMMARY_GRID_SECTION_ID =
+            "analytics-nodes-grid-section";
+        this.ANALYTICSNODE_SUMMARY_CHART_ID = 'analytics-nodes-chart';
+        this.ANALYTICSNODE_SUMMARY_LIST_SECTION_ID =
+            'analytics-nodes-list-section';
+        this.ANALYTICSNODE_SUMMARY_SCATTERCHART_SECTION_ID =
+            'analytics-nodes-scatterchart-section';
+        this.CACHE_ANALYTICSNODE = 'cache-analytics-nodes';
+        this.ANALYTICSNODE_DETAILS_PAGE_ID = 'analytics_nodes_details';
+        this.ANALYTICSNODE_TAB_SECTION_ID = 'analytics_nodes_tab_section';
+        this.ANALYTICSNODE_TAB_VIEW_ID = 'analytics_nodes_tab_view';
+        this.ANALYTICSNODE_TABS_ID = 'analytics_nodes_tab';
+        this.ANALYTICSNODE_DETAILS_SECTION_ID = 'analytics_nodes_detail_section';
+        this.ANALYTICSNODE_DETAIL_PAGE_ID = 'analytics_node_detail_page';
+        this.ANALYTICSNODE_GENERATORS_GRID_SECTION_ID = 'analytics_node_generators_grid_section';
+        this.ANALYTICSNODE_GENERATORS_GRID_ID = 'analytics_node_generators_grid';
+        this.ANALYTICSNODE_GENERATORS_TITLE = 'Generators';
+
+
         this.TMPL_CORE_GENERIC_EDIT = 'core-generic-edit-form-template';
         this.TMPL_CORE_GENERIC_DEL = 'core-generic-delete-form-template';
 

--- a/webroot/menu.xml
+++ b/webroot/menu.xml
@@ -186,6 +186,165 @@ and need to add the iconClass tag wherever we need to show some icons
                     </items>
                 </item>
                 <item>
+                    <label>Infrastructure MVC</label>
+                    <init>/monitor/infrastructure/common/ui/js/monitor.infra.init.js</init>
+                    <resources>
+                        <resource>
+                            <rootDir>/monitor/infra/common/ui</rootDir>
+                            <js>monitor_infra_constants.js</js>
+                            <js>monitor_infra_utils.js</js>
+                            <view>monitor_infra_common.view</view>
+                        </resource>
+                    </resources>
+                    <iconClass>icon-desktop</iconClass>
+                    <access>
+                        <roles>
+                            <role>superAdmin</role>
+                        </roles>
+                        <orchModels>
+                           <model>test</model>
+                           <!-- <model>openstack</model>
+                            <model>cloudstack</model>
+                            <model>vcenter</model> -->
+                       
+                        </orchModels>
+                        <accessFn>hideInFederatedvCenter</accessFn>
+                    </access>
+                    <items>
+                        <item>
+                            <hash>mon_infra_dashboardmvc</hash>
+                            <label>Dashboard</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infra/dashboard/ui</rootDir>
+                                    <view>monitor_infra_dashboard.view</view>
+                                    <js>monitor_infra_dashboard.js</js>
+                                    <class>infraMonitorDashboardView</class>
+                                </resource>
+                                 <resource>
+                                    <rootDir>/common/ui</rootDir>
+                                    <js>controller.app.js</js>
+                                </resource>
+                            </resources>
+                            <queryParams>
+                                <tab>vRouters</tab>
+                            </queryParams>
+                            <searchStrings>Infrastructure Dashboard</searchStrings>
+                        </item>
+                        <item>
+                            <hash>mon_infra_mxmvc</hash>
+                            <label>MX Visualisation</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infra/mx/ui</rootDir>
+                                    <view>monitor_infra_mx.view</view>
+                                    <js>monitor_infra_mx.js</js>
+                                    <class>mxRenderer</class>
+                                </resource>
+                            </resources>
+                        </item>
+                        <item>
+                            <hash>mon_infra_underlaymvc</hash>
+                            <label>Physical Topology</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infra/underlay/ui</rootDir>
+                                    <view>monitor_infra_underlay.view</view>
+                                    <view>flow_queries.view</view>
+                                    <view>queries.view</view>
+                                    <js>monitor_infra_underlay.js</js>
+                                    <js>flow_queries.js</js>
+                                    <class>underlayRenderer</class>
+                                </resource>
+                                <resource>
+                                    <rootDir>/monitor/infra/vrouter/ui</rootDir>
+                                    <view>monitor_infra_vrouter.view</view>
+                                    <js>monitor_infra_vrouter.js</js>
+                                    <js>monitor_infra_vrouter_flows.js</js>
+                                    <js>monitor_infra_vrouter_details.js</js>
+                                    <js>monitor_infra_vrouter_interfaces.js</js>
+                                    <js>monitor_infra_vrouter_networks.js</js>
+                                    <js>monitor_infra_vrouter_acl.js</js>
+                                    <js>monitor_infra_vrouter_flows.js</js>
+                                    <js>monitor_infra_vrouter_routes.js</js>
+                                </resource>
+                            </resources>
+                        </item>
+                        <item>
+                            <hash>mon_infra_controlmvc</hash>
+                            <label>Control Nodes</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infrastructure/controlnode/ui</rootDir>
+                                    <js>controlnode.main.js</js>
+                                    <class>controlNodesLoader</class>
+                                    <renderFn>renderControlNode</renderFn>
+                                </resource>
+                            </resources>
+                            <searchStrings>Monitor Control Nodes</searchStrings>
+                        </item>
+                        <item>
+                            <hash>mon_infra_vroutermvc</hash>
+                            <label>Virtual Routers</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infra/vrouter/ui</rootDir>
+                                    <view>monitor_infra_vrouter.view</view>
+                                    <js>monitor_infra_vrouter.js</js>
+                                    <js>monitor_infra_vrouter_summary.js</js>
+                                    <js>monitor_infra_vrouter_details.js</js>
+                                    <js>monitor_infra_vrouter_interfaces.js</js>
+                                    <js>monitor_infra_vrouter_networks.js</js>
+                                    <js>monitor_infra_vrouter_acl.js</js>
+                                    <js>monitor_infra_vrouter_flows.js</js>
+                                    <js>monitor_infra_vrouter_routes.js</js>
+                                    <class>cmpNodesView</class>
+                                </resource>
+                            </resources>
+                            <searchStrings>Monitor Compute Nodes</searchStrings>
+                        </item>
+                        <item>
+                            <hash>mon_infra_analyticsmvc</hash>
+                            <label>Analytics Nodes</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infrastructure/analyticsnode/ui</rootDir>
+                                    <js>analyticsnode.main.js</js>
+                                    <class>analyticsNodesLoader</class>
+                                    <renderFn>renderAnalyticsNode</renderFn>
+                                </resource>
+                            </resources>
+                            <searchStrings>Monitor Analytics Nodes</searchStrings>
+                        </item>
+                        <item>
+                            <hash>mon_infra_configmvc</hash>
+                            <label>Config Nodes</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infrastructure/confignode/ui</rootDir>
+                                    <js>confignode.main.js</js>
+                                    <class>configNodesLoader</class>
+                                    <renderFn>renderConfigNode</renderFn>
+                                </resource>
+                            </resources>
+                            <searchStrings>Monitor Config Nodes</searchStrings>
+                        </item>
+                        <item>
+                            <hash>mon_infra_databasemvc</hash>
+                            <label>Database Nodes</label>
+                            <resources>
+                                <resource>
+                                    <rootDir>/monitor/infrastructure/databasenode/ui</rootDir>
+                                    <js>databasenode.main.js</js>
+                                    <class>databaseNodesLoader</class>
+                                    <renderFn>renderDatabaseNode</renderFn>
+                                </resource>
+                            </resources>
+                            <searchStrings>Monitor Database Nodes</searchStrings>
+                        </item>
+                    </items>
+                </item>
+                <item>
                     <label>Networking</label>
                     <iconClass>icon-sitemap</iconClass>
                     <init>/monitor/networking/ui/js/nm.init.js</init>

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/analyticsnode.main.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/analyticsnode.main.js
@@ -1,0 +1,39 @@
+var analyticsNodesLoader = new AnalyticsNodesLoader();
+
+function AnalyticsNodesLoader() {
+    this.load = function(paramObject) {
+        var self = this,
+            currMenuObj = globalObj.currMenuObj,
+            hashParams = paramObject['hashParams'],
+            rootDir = currMenuObj['resources']['resource'][0]['rootDir'],
+            pathAnalyticsNodeView = rootDir + '/js/views/AnalyticsNodeView.js',
+            renderFn = paramObject['renderFn'];
+
+        if (self.analyticsNodeView == null) {
+            requirejs([pathAnalyticsNodeView], function(AnalyticsNodeView) {
+                self.analyticsNodeView = new AnalyticsNodeView();
+                self.renderView(renderFn, hashParams);
+            });
+        } else {
+            self.renderView(renderFn, hashParams);
+        }
+    };
+    this.renderView = function(renderFn, hashParams) {
+        $(contentContainer).html("");
+        if(hashParams.view == "details") {
+            this.analyticsNodeView.renderAnalyticsNodeDetails({
+                    hashParams: hashParams});
+        } else {
+            this.analyticsNodeView.renderAnalyticsNode({
+                    hashParams: hashParams});
+        }
+    };
+
+    this.updateViewByHash = function(hashObj, lastHashObj) {
+        this.load({hashParams : hashObj});
+    };
+
+    this.destroy = function() {
+
+    };
+}

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeDetailPageView.js
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view',
+], function (_, ContrailView) {
+    var AnalyticsNodesDetailPageView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this;
+            var detailsTemplate = contrail.getTemplate4Id(
+                    cowc.TMPL_2COLUMN_1ROW_2ROW_CONTENT_VIEW);
+            var viewConfig = this.attributes.viewConfig;
+            var leftContainerElement = $('#left-column-container');
+            this.$el.html(detailsTemplate);
+
+            self.renderView4Config($('#left-column-container'), null,
+                    getAnalyticsNodeDetailPageViewConfig(viewConfig));
+        }
+    });
+    var getAnalyticsNodeDetailPageViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+        return {
+            elementId: ctwl.ANALYTICSNODE_DETAIL_PAGE_ID,
+            title: ctwl.TITLE_DETAILS,
+            view: "DetailsView",
+            viewConfig: {
+                ajaxConfig: {
+                    url: contrail.format(
+                            monitorInfraConstants.
+                            monitorInfraUrls['ANALYTICS_DETAILS'], hostname),
+                    type: 'GET'
+                },
+                templateConfig: getDetailsViewTemplateConfig(),
+                app: cowc.APP_CONTRAIL_CONTROLLER,
+                dataParser: function(result) {
+                    var analyticsNodeData = result;
+                    var obj = monitorInfraParsers.
+                    parseAnalyticsNodesDashboardData([result])[0];
+                    //Further parsing required for Details page done below
+
+                    var overallStatus;
+                    try{
+                        overallStatus = monitorInfraUtils.
+                            getOverallNodeStatusForDetails(obj);
+                    }catch(e){overallStatus = "<span> "+
+                        statusTemplate({sevLevel:sevLevels['ERROR'],
+                            sevLevels:sevLevels})+" Down</span>";}
+
+                    try{
+                        //Add the process status list with uptime
+                        var procStateList = jsonPath(analyticsNodeData,
+                                "$..NodeStatus.process_info")[0];
+                        obj['analyticsProcessStatusList'] =
+                            getStatusesForAllAnalyticsProcesses(procStateList);
+                    }catch(e){}
+
+                    obj['name'] = hostname;
+
+                    obj['ip'] = getIPAddress(analyticsNodeData);
+
+                    obj['overallStatus'] = overallStatus;
+
+                    obj['cpu'] = getCpuText(obj['cpu']);
+
+                    obj['analyticsMessages'] = getAnalyticsMessages(
+                                                        analyticsNodeData);
+
+                    obj['generators'] = getGenerators(analyticsNodeData);
+
+                    obj['lastLogTimestamp'] = getLastLogTime(analyticsNodeData);
+                    return obj;
+                }
+            }
+        }
+    }
+
+    function getDetailsViewTemplateConfig() {
+        return {
+            title: 'Analytics Node',
+            templateGenerator: 'BlockListTemplateGenerator',
+            theme: 'widget-box',
+            keyClass: 'label-blue',
+            templateGeneratorConfig: getTemplateGeneratorConfig()
+        };
+    };
+
+    function getTemplateGeneratorConfig() {
+        var templateGeneratorConfig = [];
+        templateGeneratorConfig = templateGeneratorConfig.concat([
+                {
+                    key: 'name',
+                    label:'Hostname',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'ip',
+                    label:'IP Address',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'version',
+                    label: 'Version',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'overallStatus',
+                    label: 'Overall Node Status',
+                    templateGenerator: 'TextGenerator'
+                }
+        ]);
+        //Add proccesses info only if the node manager is installed
+        templateGeneratorConfig = templateGeneratorConfig.concat(
+            (monitorInfraConstants.IS_NODE_MANAGER_INSTALLED)?
+                    [
+                         {
+                             key: 'processes',
+                             label: 'Processes',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'analyticsProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['COLLECTOR'],
+                             label: 'Collector',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'analyticsProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['QUERYENGINE'],
+                             label: 'Query Engine',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'analyticsProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['APISERVER'],
+                             label: 'API Server',
+                             templateGenerator: 'TextGenerator'
+                         }
+                    ]
+                    : []
+        );
+
+        templateGeneratorConfig = templateGeneratorConfig.concat(
+                [
+                    {
+                        key: 'cpu',
+                        label: 'CPU',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'memory',
+                        label: 'Memory',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'analyticsMessages',
+                        label: 'Messages',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'generators',
+                        label: 'Generators',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'lastLogTimestamp',
+                        label: 'Last Log',
+                        templateGenerator: 'TextGenerator'
+                    }
+                ]
+        );
+        return templateGeneratorConfig;
+    }
+
+    function getIPAddress(aNodeData) {
+        var ips = '';
+        iplist = getValueByJsonPath(aNodeData,"CollectorState;self_ip_list",[]);
+        if(iplist != null && iplist.length>0){
+            for (var i=0; i< iplist.length;i++){
+                if(i+1 == iplist.length) {
+                    ips = ips + iplist[i];
+                } else {
+                    ips = ips + iplist[i] + ', ';
+                }
+            }
+        } else {
+            ips = noDataStr;
+        }
+        return ips;
+    }
+
+    function getCpuText(cpu) {
+        return (cpu != '-')? cpu + ' %' : cpu;
+    }
+
+    function getAnalyticsMessages(aNodeData) {
+        var msgs = monitorInfraUtils.getAnalyticsMessagesCountAndSize(
+                                            aNodeData,['contrail-collector']);
+        return msgs['count']  + ' [' + formatBytes(msgs['size']) + ']';
+    }
+
+    function getStatusesForAllAnalyticsProcesses(processStateList){
+        var ret = {};
+        if(processStateList != null){
+            for(var i=0; i < processStateList.length; i++){
+                var currProc = processStateList[i];
+                if (currProc.process_name == "contrail-query-engine"){
+                    ret[monitorInfraConstants.UVEModuleIds['QUERYENGINE']]
+                                                = getProcessUpTime(currProc);
+                }  else if (currProc.process_name ==
+                                "contrail-analytics-nodemgr"){
+                    ret[monitorInfraConstants.UVEModuleIds['ANALYTICS_NODEMGR']]
+                                                = getProcessUpTime(currProc);
+                }  else if (currProc.process_name == "contrail-analytics-api"){
+                    ret[monitorInfraConstants.UVEModuleIds['APISERVER']]
+                                                = getProcessUpTime(currProc);
+                } else if (currProc.process_name == "contrail-collector"){
+                    ret[monitorInfraConstants.UVEModuleIds['COLLECTOR']]
+                                                = getProcessUpTime(currProc);
+                }
+            }
+        }
+        return ret;
+    }
+
+    //Derive the IFmap connection status from the parsed data
+    function getIfMapConnectionStatus(ctrlNodeData) {
+        var cnfNode = '';
+        try {
+            var url = ctrlNodeData.BgpRouterState.ifmap_info.url;
+            if (url != null && url != undefined && url != "") {
+                var pos = url.indexOf(':8443');
+                if (pos != -1)
+                    cnfNode = url.substr(0, pos);
+                pos = cnfNode.indexOf('https://');
+                if (pos != -1)
+                    cnfNode = cnfNode.slice(pos + 8);
+            }
+            var status = ctrlNodeData.BgpRouterState.ifmap_info.connection_status;
+            var stateChangeAtTime = ctrlNodeData.BgpRouterState.
+                                        ifmap_info.connection_status_change_at;
+            var stateChangeSince = "";
+            var statusString = "";
+            if (stateChangeAtTime != null) {
+                var stateChangeAtTime = new XDate(
+                        stateChangeAtTime / 1000);
+                var currTime = new XDate();
+                stateChangeSince = diffDates(stateChangeAtTime,
+                        currTime);
+            }
+            if (status != null && status != undefined && status != "") {
+                if (stateChangeSince != "") {
+                    if (status.toLowerCase() == "up"
+                            || status.toLowerCase() == "down") {
+                        status = status + " since";
+                    }
+                    statusString = status + " " + stateChangeSince;
+                } else {
+                    statusString = status;
+                }
+            }
+            if (statusString != "") {
+                cnfNode = cnfNode.concat(' (' + statusString + ')');
+            }
+        } catch (e) {
+        }
+        return ifNull(cnfNode, noDataStr);
+    }
+
+    //Derive the ip and status of Analytics Node this is connecting to
+    function getAnalyticsNodeDetails(ctrlNodeData) {
+        var anlNode = noDataStr;
+        var secondaryAnlNode, status;
+        try{
+           anlNode = jsonPath(
+                   ctrlNodeData,"$..ModuleClientState..primary")[0].
+                       split(':')[0];
+           status = jsonPath(ctrlNodeData,"$..ModuleClientState..status")[0];
+           secondaryAnlNode = ifNull(jsonPath(ctrlNodeData,
+                   "$..ModuleClientState..secondary")[0],"").split(':')[0];
+        }catch(e){
+           anlNode = "--";
+        }
+        try{
+           if(anlNode != null && anlNode != noDataStr &&
+                   status.toLowerCase() == "established")
+              anlNode = anlNode.concat(' (Up)');
+        }catch(e){
+           if(anlNode != null && anlNode != noDataStr) {
+              anlNode = anlNode.concat(' (Down)');
+           }
+        }
+        if(secondaryAnlNode != null && secondaryAnlNode != "" &&
+                secondaryAnlNode != "0.0.0.0"){
+           anlNode = anlNode.concat(', ' + secondaryAnlNode);
+        }
+        return ifNull(anlNode,noDataStr);
+    }
+
+    function getAnalyticsNodeMessageInfo(ctrlNodeData) {
+        var msgs = monitorInfraUtils.getAnalyticsMessagesCountAndSize(
+                ctrlNodeData,['contrail-control']);
+        return msgs['count']  + ' [' + formatBytes(msgs['size']) + ']';
+    }
+
+    function getGenerators(aNodeData) {
+        var ret='';
+        var genno;
+        try{
+            if(aNodeData.CollectorState["generator_infos"]!=null){
+                genno = aNodeData.CollectorState["generator_infos"].length;
+            };
+            ret = ret + ifNull(genno,noDataStr);
+        }catch(e){ return noDataStr;}
+        return ret;
+    }
+
+    function getLastLogTime(aNodeData) {
+        var lmsg;
+        lmsg = getLastLogTimestamp(aNodeData,"analytics");
+        if(lmsg != null){
+            try{
+                return new Date(parseInt(lmsg)/1000).toLocaleString();
+            }catch(e){return noDataStr;}
+        } else return noDataStr;
+        }
+
+    return AnalyticsNodesDetailPageView;
+});

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeDetailsView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeDetailsView.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var AnalyticsDetailsView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            var currentHashParams = layoutHandler.getURLHashParams(),
+                tabConfig = getAnalyticsTabsViewConfig (currentHashParams);
+
+            this.renderView4Config(this.$el, null, tabConfig, null, null, null);
+        }
+    });
+
+    function getAnalyticsTabsViewConfig(currHashParams) {
+        var options = {
+                hostname: currHashParams.focusedElement.node
+            };
+        return {
+            elementId: cowu.formatElementId([ctwl.ANALYTICSNODE_TAB_SECTION_ID]),
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.ANALYTICSNODE_TAB_VIEW_ID,
+                                view: "AnalyticsNodeTabView",
+                                viewPathPrefix:
+                                    ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                                app: cowc.APP_CONTRAIL_CONTROLLER,
+                                viewConfig: options
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+    };
+
+    return AnalyticsDetailsView;
+
+});

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeGeneratorsGridView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeGeneratorsGridView.js
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view',
+    'contrail-list-model'
+], function (_, ContrailView, ContrailListModel) {
+    var hostname;
+    var AnalyticsNodePeersGridView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this;
+            var viewConfig = this.attributes.viewConfig;
+            hostname = viewConfig['hostname'];
+            var remoteAjaxConfig = {
+                    remote: {//TODO need to verify if the pagination
+                                //is actually working
+                        ajaxConfig: {
+                            url: contrail.format(monitorInfraConstants.
+                                    monitorInfraUrls['ANALYTICS_GENERATORS'],
+                                    hostname, 50),
+                            type: "GET",
+                        },
+                        dataParser: parseGenInfo
+                    },
+                    cacheConfig: {
+                        ucid: "analyticsnode_generators_list"
+                    }
+            }
+            var contrailListModel = new ContrailListModel(remoteAjaxConfig);
+
+            self.renderView4Config(this.$el, contrailListModel,
+                    getAnalyticsNodeGeneratorsViewConfig(viewConfig));
+        }
+    });
+
+    var getAnalyticsNodeGeneratorsViewConfig = function (viewConfig) {
+        return {
+            elementId : ctwl.ANALYTICSNODE_GENERATORS_GRID_SECTION_ID,
+            view : "SectionView",
+            viewConfig : {
+                rows : [ {
+                    columns : [ {
+                        elementId : ctwl.ANALYTICSNODE_GENERATORS_GRID_ID,
+                        title : ctwl.ANALYTICSNODE_GENERATORS_TITLE,
+                        view : "GridView",
+                        viewConfig : {
+                            elementConfig :
+                                getAnalyticsNodeGeneratorsGridConfig()
+                        }
+                    } ]
+                } ]
+            }
+        }
+    }
+
+
+    function getAnalyticsNodeGeneratorsGridConfig() {
+
+    var columns = [
+    {
+        field:"name",
+        name:"Name",
+        width:110
+    },
+    {
+        field:"status",
+        name:"Status",
+        width:210
+    },
+    {
+        field:'messages',
+        headerAttributes:{style:'min-width:160px;'},
+        width:160,
+        name:"Messages"
+    },
+    {
+        field:"formattedMsgBytes",
+        name:"Bytes",
+        width:140,
+        sortField:"bytes"
+    }];
+    var gridElementConfig = {
+        header : {
+            title : {
+                text : ctwl.ANALYTICSNODE_GENERATORS_TITLE
+            }
+        },
+        columnHeader : {
+            columns : columns
+        },
+        body : {
+            options : {
+                detail : false,
+                checkboxSelectable : false
+            },
+            dataSource : {
+                data : []
+            }
+        },
+        statusMessages: {
+            loading: {
+                text: 'Loading Generators..',
+            },
+            empty: {
+                text: 'No Generators to display'
+            },
+            errorGettingData: {
+                type: 'error',
+                iconClasses: 'icon-warning',
+                text: 'Error in getting Data.'
+            }
+        }
+    };
+    return gridElementConfig;
+
+}
+
+    this.parseGenInfo = function(response)
+    {
+        var ret = [];
+        response = response['data'];
+        if(response != null &&  response.value != null){
+            response = response.value;
+            $.each(response,function(i,d){
+                var name = d.name;
+                var status = noDataStr;
+                var rawJson = d;
+                var generatorInfo = getValueByJsonPath(d,
+                        "value;ModuleServerState;generator_info");
+                var collectorName = getValueByJsonPath(d,
+                        "value;ModuleClientState;client_info;collector_name");
+                var strtTime = getValueByJsonPath(d,
+                        "value;ModuleClientState;client_info;start_time");
+                status = getStatusForGenerator(generatorInfo,
+                                collectorName,
+                                strtTime);
+                var msgStats;
+                try {
+                    msgStats=
+                        d['value']["ModuleServerState"]["msg_stats"][0]["msgtype_stats"];
+                }catch(e){}
+                var msgsBytes = 0;
+                var messages = 0;
+                if(msgStats != null){
+                    for (var i = 0; i < msgStats.length; i++) {
+                        msgsBytes += parseInt(msgStats[i]["bytes"]);
+                        messages += parseInt(msgStats[i]["messages"]);
+                    }
+                }
+                var formattedMsgBytes = formatBytes(msgsBytes);
+
+                ret.push({name:name,
+                    status:status,
+                    messages:messages,
+                    bytes:msgsBytes,
+                    formattedMsgBytes:formattedMsgBytes,
+                    raw_json:rawJson});
+            });
+        }
+        return ret;
+    }
+
+    function getStatusForGenerator(data,collectorName,strtTime){
+        if(data != null) {
+            var maxConnectTimeGenerator =
+                getMaxGeneratorValueInArray(data,"connect_time");
+            var maxResetTime =
+                jsonPath(maxConnectTimeGenerator,"$..reset_time")[0];
+            var maxConnectTime =
+                jsonPath(maxConnectTimeGenerator,"$..connect_time")[0];
+            var statusString = '--';
+            var resetTime = new XDate(maxResetTime/1000);
+            var connectTime = new XDate(maxConnectTime/1000);
+            var startTime;
+            var maxGeneratorHostName =
+                jsonPath(maxConnectTimeGenerator,"$..hostname")[0];
+            if(strtTime != null){
+                startTime = new XDate(strtTime/1000);
+            }
+            var currTime = new XDate();
+            if(maxResetTime > maxConnectTime){//Means disconnected
+                statusString = 'Disconnected since ' +
+                                diffDates(resetTime,currTime);
+            } else {
+                if(maxGeneratorHostName != collectorName){
+                    statusString = "Connection Error since " +
+                                    diffDates(connectTime,currTime);
+                } else {
+                    statusString = "Up since " +
+                                diffDates(startTime,currTime) +
+                                " , Connected since " +
+                                diffDates(connectTime,currTime);
+                }
+            }
+            return statusString;
+        } else {
+            return "-";
+        }
+    }
+
+    return AnalyticsNodePeersGridView;
+});

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeListView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeListView.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view','monitor-infra-analyticsnode-model' ],
+        function(
+                _, ContrailView, AnalyticsNodeListModel) {
+            var AnalyticsNodeListView = ContrailView.extend({
+                render : function() {
+                    var analyticsNodeListModel = new AnalyticsNodeListModel();
+                    this.renderView4Config(this.$el, analyticsNodeListModel,
+                            getAnalyticsNodeListViewConfig());
+                }
+            });
+
+            function getAnalyticsNodeListViewConfig() {
+                var viewConfig = {
+                        rows : [
+                            {
+                                columns : [{
+                                    elementId :
+                                        ctwl.ANALYTICSNODE_SUMMARY_CHART_ID,
+                                    title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                    view : "AnalyticsNodeScatterChartView",
+                                    viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
+                                    app : cowc.APP_CONTRAIL_CONTROLLER,
+                                }]
+                            },{
+                                columns : [{
+                                    elementId :
+                                        ctwl.ANALYTICSNODE_SUMMARY_GRID_ID,
+                                    title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                    view : "AnalyticsNodeSummaryGridView",
+                                    viewPathPrefix:
+                                        ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                                    app : cowc.APP_CONTRAIL_CONTROLLER,
+                                    viewConfig : {
+
+                                    }
+                                }]
+                            }
+                            ]
+                        };
+                return {
+                    elementId : cowu.formatElementId([
+                         ctwl.ANALYTICSNODE_SUMMARY_LIST_SECTION_ID ]),
+                    view : "SectionView",
+                    viewConfig : viewConfig
+                };
+            }
+            return AnalyticsNodeListView;
+        });

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeSummaryGridView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeSummaryGridView.js
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([ 'underscore', 'contrail-view' ],function(_, ContrailView) {
+            var AnalyticsNodeGridView = ContrailView
+                    .extend({
+                        render : function() {
+                            var self = this,
+                                viewConfig = this.attributes.viewConfig,
+                                pagerOptions = viewConfig['pagerOptions'];
+                            this.renderView4Config(
+                                self.$el,
+                                self.model,
+                                getAnalyticsNodeSummaryGridViewConfig(
+                                    pagerOptions));
+                        }
+                    });
+
+            function getAnalyticsNodeSummaryGridViewConfig(
+                    pagerOptions) {
+                return {
+                    elementId : ctwl.ANALYTICSNODE_SUMMARY_GRID_SECTION_ID,
+                    view : "SectionView",
+                    viewConfig : {
+                        rows : [ {
+                            columns : [ {
+                                elementId : ctwl.ANALYTICSNODE_SUMMARY_GRID_ID,
+                                title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                view : "GridView",
+                                viewConfig : {
+                                    elementConfig :
+                                        getAnalyticsNodeSummaryGridConfig(
+                                            pagerOptions)
+                                }
+                            } ]
+                        } ]
+                    }
+                };
+            }
+
+            function getAnalyticsNodeSummaryGridConfig(
+                    pagerOptions) {
+                var columns = [
+                   {
+                       field:"name",
+                       id:"name",
+                       name:"Host name",
+                       formatter:function(r,c,v,cd,dc) {
+                          return cellTemplateLinks({
+                              cellText:'name',
+                              name:'name',
+                              statusBubble:true,
+                              rowData:dc});
+                       },
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.name;
+                           }
+                       },
+                       events: {
+                          onClick: onClickHostName
+                       },
+                       cssClass: 'cell-hyperlink-blue',
+                       minWidth:110,
+                       sortable:true
+                   },
+                   {
+                       field:"ip",
+                       id:"ip",
+                       name:"IP Address",
+                       minWidth:110,
+                       sortable:true,
+                       formatter:function(r,c,v,cd,dc){
+                           return summaryIpDisplay(dc['ip'],
+                                   dc['summaryIps']);
+                       },
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.ip;
+                           }
+                       },
+                       sorter : comparatorIP
+                   },
+                   {
+                       field:"version",
+                       id:"version",
+                       name:"Version",
+                       sortable:true,
+                       minWidth:110
+                   },
+                   {
+                       field:"status",
+                       id:"status",
+                       name:"Status",
+                       sortable:true,
+                       formatter:function(r,c,v,cd,dc) {
+                           return getNodeStatusContentForSummayPages(dc,'html');
+                       },
+                       searchFn:function(d) {
+                           return getNodeStatusContentForSummayPages(d,'text');
+                       },
+                       minWidth:110,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return getNodeStatusContentForSummayPages(dc,
+                                   'text');
+                           }
+                       }
+                   },
+                   {
+                       field:"cpu",
+                       id:"analyticsCpu",
+                       name:"CPU (%)",
+                       formatter:function(r,c,v,cd,dc) {
+                           return '<div class="gridSparkline display-inline">' +
+                                  '</div><span class="display-inline">' +
+                                    dc['cpu'] + '</span>';
+                       },
+                       asyncPostRender: renderSparkLines,
+                       searchFn:function(d){
+                           return d['cpu'];
+                       },
+                       minWidth:120,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.cpu
+                           }
+                       }
+                   },
+                   {
+                       field:"memory",
+                       id:"analyticsMem",
+                       sortable:true,
+                       name:"Memory",
+                       minWidth:150,
+                       sortField:"y"
+                   },
+                   {
+                       field:"genCount",
+                       id:"genCount",
+                       sortable:true,
+                       name:"Generators",
+                       minWidth:85
+                   }
+                ];
+                var gridElementConfig = {
+                    header : {
+                        title : {
+                            text : ctwl.ANALYTICSNODE_SUMMARY_TITLE
+                        }
+                    },
+                    columnHeader : {
+                        columns : columns
+
+                    },
+                    body : {
+                        options : {
+                          detail : false,
+                          checkboxSelectable : false
+                        },
+                        dataSource : {
+                            remote : {
+                                ajaxConfig : {
+                                    url : ctwl.ANALYTICSNODE_SUMMARY
+                                }
+                            },
+                            cacheConfig : {
+                                ucid: ctwl.CACHE_ANALYTICSNODE
+                            }
+                        }
+                    }
+
+                };
+                return gridElementConfig;
+            }
+
+            function onClickHostName(e, selRowDataItem) {
+                var name = selRowDataItem.name, hashParams = null,
+                    triggerHashChange = true, hostName;
+
+                hostName = selRowDataItem['name'];
+                var hashObj = {
+                        type: "analyticsNode",
+                        view: "details",
+                        focusedElement: {
+                            node: name,
+                            tab: 'details'
+                        }
+                    };
+
+                if(contrail.checkIfKeyExistInObject(true, hashParams,
+                        'clickedElement')) {
+                    hashObj.clickedElement = hashParams.clickedElement;
+                }
+
+                layoutHandler.setURLHashParams(hashObj, {
+                    p: "mon_infra_analyticsmvc",
+                    merge: false,
+                    triggerHashChange: triggerHashChange});
+
+            };
+
+            return AnalyticsNodeGridView;
+        });

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeTabView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeTabView.js
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var AnalyticsNodesTabView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            self.renderView4Config(self.$el, null,
+                    getAnalyticsNodeTabViewConfig(viewConfig));
+        }
+    });
+
+    var getAnalyticsNodeTabViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+
+        return {
+            elementId: ctwl.ANALYTICSNODE_DETAILS_SECTION_ID,
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.ANALYTICSNODE_TABS_ID,
+                                view: "TabsView",
+                                viewConfig: getAnalyticsNodeTabsViewConfig(
+                                                viewConfig)
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    };
+
+    function getAnalyticsNodeTabsViewConfig(viewConfig) {
+        return {
+            theme: 'default',
+            active: 0,
+            activate: function (e, ui) {
+                var selTab = $(ui.newTab.context).text();
+                if (selTab == ctwl.TITLE_PORT_DISTRIBUTION) {
+                    $('#' + ctwl.NETWORK_PORT_DIST_ID).trigger('refresh');
+                } else if (selTab == ctwl.TITLE_INSTANCES) {
+                    $('#' + ctwl.PROJECT_INSTANCE_GRID_ID).data('contrailGrid').
+                        refreshView();
+                }
+            },
+            tabs: [
+               {
+                   elementId: 'analyticsnode_detail_id',
+                   title: 'Details',
+                   view: "AnalyticsNodeDetailPageView",
+                   viewPathPrefix: ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                   viewConfig: viewConfig
+               },
+               {
+                   elementId: 'analyticsnode_generators_id',
+                   title: 'Generators',
+                   view: "AnalyticsNodeGeneratorsGridView",
+                   viewPathPrefix: ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                   viewConfig: viewConfig
+               }
+            ]
+        }
+    }
+
+    return AnalyticsNodesTabView;
+});

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeView.js
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var AnalyticsNodeView = ContrailView.extend({
+        el: $(contentContainer),
+        renderAnalyticsNode: function (viewConfig) {
+            this.renderView4Config(this.$el, null,
+                    getAnalyticsNodeListConfig());
+        },
+        renderAnalyticsNodeDetails : function (viewConfig) {
+            this.renderView4Config(this.$el, null, getAnalyticsNodeDetails());
+        }
+    });
+
+    function getAnalyticsNodeListConfig() {
+        return {
+            elementId: cowu.formatElementId([
+                ctwl.ANALYTICSNODE_SUMMARY_PAGE_ID]),
+            view: "AnalyticsNodeListView",
+            viewPathPrefix: ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+
+    function getAnalyticsNodeDetails() {
+        return {
+            elementId: cowu.formatElementId([ctwl.
+                                             ANALYTICSNODE_DETAILS_PAGE_ID]),
+            view: "AnalyticsNodeDetailsView",
+            viewPathPrefix: ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+    return AnalyticsNodeView;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel.js
@@ -1,0 +1,56 @@
+define(['contrail-list-model'], function(ContrailListModel) {
+    var AnalyticsNodeListModel = function() {
+        if (AnalyticsNodeListModel.prototype.singletonInstance) {
+            return AnalyticsNodeListModel.prototype.singletonInstance;
+        }
+        var listModelConfig = {
+            remote : {
+                ajaxConfig : {
+                    url : ctwl.ANALYTICSNODE_SUMMARY_URL
+                },
+                dataParser : monitorInfraParsers.parseAnalyticsNodesDashboardData
+            },
+            vlRemoteConfig : {
+                vlRemoteList : [{
+                    getAjaxConfig : function() {
+                        return monitorInfraUtils
+                            .getGeneratorsAjaxConfigForInfraNodes(
+                                'analyticsNodeDS');
+                    },
+                    successCallback : function(response, contrailListModel) {
+                        monitorInfraUtils
+                            .parseAndMergeGeneratorWithPrimaryDataForInfraNodes(
+                                response, contrailListModel);
+                    }
+                }, {
+                    getAjaxConfig : function() {
+                        var postData =
+                            getPostData("analytics-node", '', '',
+                                'CollectorState:generator_infos', '');
+                        return {
+                            url : TENANT_API_URL,
+                            type : 'POST',
+                            data : JSON.stringify(postData)
+                        };
+                    },
+                    sucessCallback : function(response, contrailListModel) {
+                        if (result != null && result[0] != null) {
+                            monitorInfraUtils
+                                .mergeCollectorDataAndPrimaryData(result[0],
+                                        contrailListModel);
+                        }
+                    }
+                }
+                //Need to add cpu stats
+                ]
+            },
+            cacheConfig : {
+                ucid : ctwc.CACHE_ANALYTICSNODE
+            }
+        };
+        AnalyticsNodeListModel.prototype.singletonInstance =
+            new ContrailListModel(listModelConfig);
+        return AnalyticsNodeListModel.prototype.singletonInstance;
+    };
+    return AnalyticsNodeListModel;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel.js
@@ -1,0 +1,43 @@
+define([
+    'contrail-list-model'
+], function (ContrailListModel) {
+    var ConfigNodeListModel = function () {
+        if(ConfigNodeListModel.prototype.singletonInstance) {
+            return ConfigNodeListModel.prototype.singletonInstance;
+        }
+        var vlRemoteList = [
+            {
+                getAjaxConfig: function() {
+                    return monitorInfraUtils
+                       .getGeneratorsAjaxConfigForInfraNodes('configNodeDS');
+                },
+                successCallback: function(response,contrailListModel) {
+                    monitorInfraUtils
+                       .parseAndMergeGeneratorWithPrimaryDataForInfraNodes(
+                       response,contrailListModel);
+                }
+            }
+                            //Need to add cpu stats
+        ];
+        var listModelConfig = {
+                remote : {
+                    ajaxConfig : {
+                        url : ctwl.CONFIGNODE_SUMMARY_URL
+                    },
+                    dataParser : monitorInfraParsers.parseConfigNodesDashboardData
+                },
+                vlRemoteConfig :{
+                    vlRemoteList : vlRemoteList
+                },
+                cacheConfig : {
+                    ucid: ctwc.CACHE_CONFIGNODE
+                }
+            };
+
+        ConfigNodeListModel.prototype.singletonInstance =
+            new ContrailListModel(listModelConfig);
+        return ConfigNodeListModel.prototype.singletonInstance;
+    };
+    return ConfigNodeListModel;
+    }
+);

--- a/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeListModel.js
@@ -1,0 +1,42 @@
+define([
+    'contrail-list-model'
+], function (ContrailListModel) {
+    var ControlNodeListModel = function () {
+        if(ControlNodeListModel.prototype.singletonInstance) {
+            return ControlNodeListModel.prototype.singletonInstance;
+        }
+        var vlRemoteConfig = [
+          {
+              getAjaxConfig: function() {
+                  return monitorInfraUtils
+                      .getGeneratorsAjaxConfigForInfraNodes('controlNodeDS');
+              },
+              successCallback: function(response,contrailListModel) {
+                  monitorInfraUtils
+                      .parseAndMergeGeneratorWithPrimaryDataForInfraNodes(
+                              response,contrailListModel);
+              }
+          }
+                              //Need to add cpu stats
+        ];
+        var listModelConfig = {
+                remote : {
+                    ajaxConfig : {
+                        url : ctwl.CONTROLNODE_SUMMARY_URL
+                    },
+                    dataParser : monitorInfraParsers.parseControlNodesDashboardData
+                },
+                vlRemoteConfig :{
+                    vlRemoteList : vlRemoteConfig
+                },
+                cacheConfig : {
+                    ucid: ctwc.CACHE_CONTROLNODE
+                }
+            };
+        ControlNodeListModel.prototype.singletonInstance =
+            new ContrailListModel(listModelConfig);
+        return ControlNodeListModel.prototype.singletonInstance;
+    };
+    return ControlNodeListModel;
+    }
+);

--- a/webroot/monitor/infrastructure/common/ui/js/models/DatabaseNodeListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/DatabaseNodeListModel.js
@@ -1,0 +1,25 @@
+define([
+    'contrail-list-model',
+], function (ContrailListModel) {
+    var DatabaseNodeListModel = function () {
+        if(DatabaseNodeListModel.prototype.singletonInstance) {
+            return DatabaseNodeListModel.prototype.singletonInstance;
+        }
+        var listModelConfig = {
+                remote : {
+                    ajaxConfig : {
+                        url : ctwl.DATABASENODE_SUMMARY_URL
+                    },
+                    dataParser : monitorInfraParsers.parseDatabaseNodesDashboardData
+                },
+                cacheConfig : {
+                    ucid: ctwc.CACHE_DATABASENODE
+                }
+            };
+        DatabaseNodeListModel.prototype.singletonInstance =
+            new ContrailListModel(listModelConfig);
+        return DatabaseNodeListModel.prototype.singletonInstance;
+    };
+    return DatabaseNodeListModel;
+    }
+);

--- a/webroot/monitor/infrastructure/common/ui/js/monitor.infra.init.js
+++ b/webroot/monitor/infrastructure/common/ui/js/monitor.infra.init.js
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'monitor/infrastructure/common/ui/js/utils/monitor.infra.utils',
+    'monitor/infrastructure/common/ui/js/utils/monitor.infra.constants',
+    'monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers'
+], function (_, MonitorInfraUtils, MonitorInfraConstants, MonitorInfraParsers) {
+    monitorInfraUtils = new MonitorInfraUtils;
+    monitorInfraConstants = new MonitorInfraConstants;
+    monitorInfraParsers = new MonitorInfraParsers;
+
+    var initJSpath = pkgBaseDir +
+        '/monitor/infrastructure/common/ui/js/monitor.infra.init.js',
+        initStatus = contentHandler.initFeatureModuleMap[initJSpath],
+        deferredObj = initStatus['deferredObj'];
+
+    initStatus['isInProgress'] = false;
+    initStatus['isComplete'] = true;
+
+    if(contrail.checkIfExist(deferredObj)) {
+        deferredObj.resolve()
+    }
+});

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.constants.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.constants.js
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore'
+], function (_) {
+    var MonitorInfraConstants = function () {
+        this.infraNodesTree;
+        this.noDataStr = '-';
+        this.controlNodetabs = ['details', 'peers', 'routes', 'console','servicechaining'];
+        this.computeNodeTabs = ['details', 'interfaces', 'networks', 'acl', 'flows','routes', 'console'];
+        this.analyticsNodeTabs = ['details', 'generators', 'qequeries', 'console'];
+        this.configNodeTabs = ['details', 'console', 'generators', 'qequeries'];
+        this.dbNodeTabs = ['details'];
+
+        this.excludeProcessList = ['contrail-config-nodemgr','contrail-analytics-nodemgr','contrail-control-nodemgr','contrail-snmp-collector','contrail-topology',
+            'contrail-vrouter-nodemgr','openstack-nova-compute','contrail-svc-monitor','contrail-schema','contrail-discovery','contrail-zookeeper','redis-sentinel','contrail-device-manager'];
+        this.vRouterDashboardChartInitialized = false;
+        this.controlNodesDashboardChartInitialized = false;
+        this.analyticsNodesDashboardChartInitialized = false;
+        this.configNodesDashboardChartInitialized = false;
+        this.computeNodeTabStrip = "compute_tabstrip";
+        this.configNodeTabStrip = "config_tabstrip";
+        this.aNodeTabStrip = "analytics_tabstrip";
+        this.ctrlNodeTabStrip = "control_tabstrip";
+        this.dbNodeTabStrip = "db_tabstrip";
+        this.infraDetailsPageCPUChartTitle = 'CPU Share (%)';
+        this.CONSOLE_LOGS_REFRESH_INTERVAL = 90000;//Auto refresh interval in console tab (ms)
+
+        this.IS_NODE_MANAGER_INSTALLED = true;
+
+        this.monitorInfraUrls = {
+                VROUTER_BASE                : '/api/admin/monitor/infrastructure/vrouter/',
+                VROUTER_SUMMARY             : '/api/admin/monitor/infrastructure/vrouters/summary',
+                VROUTER_CACHED_SUMMARY      : '/api/admin/monitor/infrastructure/vrouters/cached-summary',
+                VROUTER_DETAILS             : '/api/admin/monitor/infrastructure/vrouter/details?hostname={0}&basic={1}',
+                VROUTER_INTERFACES          : '/api/admin/monitor/infrastructure/vrouter/interface',
+                VROUTER_NETWORKS            : '/api/admin/monitor/infrastructure/vrouter/vn',
+                VROUTER_ACL                 : '/api/admin/monitor/infrastructure/vrouter/acl',
+                VROUTER_FLOWS               : '/api/admin/monitor/infrastructure/vrouter/flows',
+                VROUTER_VRF_LIST            : '/api/admin/monitor/infrastructure/vrouter/vrf-list?ip={0}&introspectPort={1}',
+                VROUTER_UNICAST_ROUTES      : '/api/admin/monitor/infrastructure/vrouter/ucast-routes',
+                VROUTER_MCAST_ROUTES        : '/api/admin/monitor/infrastructure/vrouter/mcast-routes',
+                VROUTER_L2_ROUTES           : '/api/admin/monitor/infrastructure/vrouter/l2-routes',
+                VROUTER_UCAST6_ROUTES       : '/api/admin/monitor/infrastructure/vrouter/ucast6-routes',
+
+                CONTROLNODE_SUMMARY         : '/api/admin/monitor/infrastructure/controlnodes/summary',
+                CONTROLNODE_DETAILS         : '/api/admin/monitor/infrastructure/controlnode/details?hostname={0}',
+                CONTROLNODE_PEERS           : '/api/admin/monitor/infrastructure/controlnode/paged-bgppeer?hostname={0}&count={1}',
+                CONTROLNODE_ROUTE_INST_LIST : '/api/admin/monitor/infrastructure/controlnode/routes/rout-inst-list?ip={0}',
+                CONTROLNODE_PEER_LIST       : '/api/admin/monitor/infrastructure/controlnode/peer-list?hostname={0}',
+                CONTROLNODE_ROUTES          : '/api/admin/monitor/infrastructure/controlnode/routes',
+
+                ANALYTICS_SUMMARY           : '/api/admin/monitor/infrastructure/analyticsnodes/summary',
+                ANALYTICS_DETAILS           : '/api/admin/monitor/infrastructure/analyticsnode/details?hostname={0}',
+                ANALYTICS_GENERATORS        : '/api/admin/monitor/infrastructure/analyticsnode/generators?hostname={0}&count={1}',
+
+                CONFIG_SUMMARY              : '/api/admin/monitor/infrastructure/confignodes/summary',
+                CONFIG_DETAILS              : '/api/admin/monitor/infrastructure/confignode/details?hostname={0}',
+
+                DATABASE_SUMMARY            : '/api/admin/monitor/infrastructure/dbnodes/summary',
+                DATABASE_DETAILS            : '/api/admin/monitor/infrastructure/dbnode/details?hostname={0}',
+
+                FLOWSERIES_CPU              : '/api/tenant/networking/flow-series/cpu?moduleId={0}&minsSince={1}&sampleCnt={2}&source={3}&endTime={4}',
+                QUERY                       : '/api/admin/reports/query',
+                MSGTABLE_CATEGORY           : '/api/admin/table/values/MessageTable/Category',
+                MSGTABLE_LEVEL              : '/api/admin/table/values/MessageTable/Level'
+        }
+
+        this.UVEModuleIds = {
+                VROUTER_AGENT       : 'contrail-vrouter-agent',
+                CONTROLNODE         : 'contrail-control',
+                COLLECTOR           : 'contrail-collector',
+                OPSERVER            : 'contrail-analytics-api',
+                QUERYENGINE         : 'contrail-query-engine',
+                APISERVER           : 'contrail-api',
+                DISCOVERY_SERVICE   : 'contrail-discovery',
+                SERVICE_MONITOR     : 'contrail-svc-monitor',
+                SCHEMA              : 'contrail-schema',
+                ANALYTICS_NODEMGR   : 'contrail-analytics-nodemgr',
+                CONFIG_NODE         : 'ConfigNode',
+                IFMAP               : 'ifmap',
+                DATABASE            : 'contrail-database',
+                KAFKA               : 'kafka'
+        }
+
+        this.controlProcsForLastTimeStamp = [this.UVEModuleIds['CONTROLNODE']];
+        this.computeProcsForLastTimeStamp = [this.UVEModuleIds['VROUTER_AGENT']];
+        this.analyticsProcsForLastTimeStamp = [this.UVEModuleIds['COLLECTOR'],
+                                               this.UVEModuleIds['OPSERVER']];
+        this.configProcsForLastTimeStamp = [this.UVEModuleIds['APISERVER'],
+                                            this.UVEModuleIds['DISCOVERY_SERVICE'],
+                                            this.UVEModuleIds['SERVICE_MONITOR'],
+                                            this.UVEModuleIds['SCHEMA']];
+        this.defaultIntrospectPort = '8085';
+
+    };
+
+    return MonitorInfraConstants;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers.js
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+       [ 'underscore' ],
+       function(_) {
+            var MonInfraParsers = function() {
+                var self = this;
+
+                //Parser for controlnode Dashboard data
+                this.parseControlNodesDashboardData = function (result) {
+
+                    var retArr = [];
+                    $.each(result,function(idx,d) {
+                        var obj = {};
+                        obj['x'] = parseFloat(jsonPath(d,'$..cpu_info.cpu_share')[0]);
+                        //Info:Need to specify the processname explictly
+                        //for which we need res memory && Convert to MB
+                        obj['y'] = parseInt(jsonPath(d,'$..meminfo.res')[0])/1024;
+                        obj['cpu'] = $.isNumeric(obj['x']) ? obj['x'].toFixed(2) : '-';
+                        obj['x'] = $.isNumeric(obj['x']) ? obj['x'] : 0;
+                        obj['y'] = $.isNumeric(obj['y']) ? obj['y'] : 0;
+                        obj['histCpuArr'] =
+                            parseUveHistoricalValues(d,'$.cpuStats.history-10');
+                        obj['uveIP'] =
+                            ifNull(jsonPath(d,'$..bgp_router_ip_list')[0],[]);
+                        obj['configIP'] = ifNull(jsonPath(d,
+                            '$..ConfigData..bgp_router_parameters.address')[0],'-');
+                        obj['isConfigMissing'] = $.isEmptyObject(jsonPath(d,
+                            '$..ConfigData')[0]) ? true : false;
+                        obj['configuredBgpPeerCnt'] =
+                            ifNull(jsonPath(d,'$.value.ConfigData.bgp-router.'+
+                            'bgp_router_refs')[0],[]).length;
+                        obj['isUveMissing'] =
+                            $.isEmptyObject(jsonPath(d,'$..BgpRouterState')[0]) ?
+                                    true : false;
+                        obj['ip'] =
+                            ifNull(jsonPath(d,'$..bgp_router_ip_list[0]')[0],'-');
+                        //If iplist is empty will display the config ip
+                        if(obj['ip'] == '-') {
+                            obj['ip'] = obj['configIP'];
+                        }
+                        obj['summaryIps'] = getControlIpAddresses(d,"summary");
+                        obj['memory'] =
+                            formatMemory(ifNull(jsonPath(d,'$..meminfo')[0]),'-');
+                        obj['size'] =
+                            ifNull(jsonPath(d,'$..output_queue_depth')[0],0)+1;
+                        obj['shape'] = 'circle';
+                        obj['name'] = d['name'];
+                        obj['link'] =
+                            {p:'mon_infra_control',q:{node:obj['name'],tab:''}};
+                        obj['version'] = ifEmpty(self.getNodeVersion(jsonPath(d,
+                            '$.value.BgpRouterState.build_info')[0]),'-');
+                        obj['totalPeerCount'] =
+                            ifNull(jsonPath(d,'$..num_bgp_peer')[0],0) +
+                            ifNull(jsonPath(d,'$..num_xmpp_peer')[0],0);
+                        //Assign totalBgpPeerCnt as false if it doesn't exist in UVE
+                        obj['totalBgpPeerCnt'] =
+                            ifNull(jsonPath(d,'$..num_bgp_peer')[0],null);
+                        obj['upBgpPeerCnt'] =
+                            ifNull(jsonPath(d,'$..num_up_bgp_peer')[0],null);
+                        obj['establishedPeerCount'] =
+                            ifNull(jsonPath(d,'$..num_up_bgp_peer')[0],0);
+                        obj['activevRouterCount'] =
+                            ifNull(jsonPath(d,'$..num_up_xmpp_peer')[0],0);
+                        obj['upXMPPPeerCnt'] =
+                            ifNull(jsonPath(d,'$..num_up_xmpp_peer')[0],0);
+                        obj['totalXMPPPeerCnt'] =
+                            ifNull(jsonPath(d,'$..num_xmpp_peer')[0],0);
+                        if(obj['totalXMPPPeerCnt'] > 0){
+                            obj['downXMPPPeerCnt'] =
+                                obj['totalXMPPPeerCnt'] - obj['upXMPPPeerCnt'];
+                        } else {
+                            obj['downXMPPPeerCnt'] = 0;
+                        }
+                        obj['downBgpPeerCnt'] = 0;
+                        if(typeof(obj['totalBgpPeerCnt']) == "number" &&
+                                typeof(obj['upBgpPeerCnt']) == "number"  &&
+                                obj['totalBgpPeerCnt'] > 0) {
+                            obj['downBgpPeerCnt'] =
+                                obj['totalBgpPeerCnt'] - obj['upBgpPeerCnt'];
+                        }
+                        if(obj['downXMPPPeerCnt'] > 0){
+                            obj['downXMPPPeerCntText'] = ", <span class='text-error'>" +
+                                obj['downXMPPPeerCnt'] + " Down</span>";
+                        } else {
+                            obj['downXMPPPeerCntText'] = "";
+                        }
+                        obj['isPartialUveMissing'] = false;
+                        obj['isIfmapDown'] = false;
+                        if(obj['isUveMissing'] == false) {
+                            obj['isPartialUveMissing'] = (isEmptyObject(jsonPath(d,
+                                '$.value.BgpRouterState.cpu_info')[0]) || isEmptyObject(
+                                jsonPath(d,'$.value.BgpRouterState.build_info')[0]) ||
+                                (obj['configIP'] == '-') || obj['uveIP'].length == 0)
+                                ? true : false;
+                            var ifmapObj =
+                                jsonPath(d,'$.value.BgpRouterState.ifmap_info')[0];
+                            if(ifmapObj != undefined &&
+                                    ifmapObj['connection_status'] != 'Up'){
+                                obj['isIfmapDown'] = true;
+                                obj['ifmapDownAt'] =
+                                    ifNull(ifmapObj['connection_status_change_at'],'-');
+                            }
+                        }
+                        obj['isNTPUnsynced'] =
+                            isNTPUnsynced(jsonPath(d,'$..NodeStatus')[0]);
+                        if(obj['downBgpPeerCnt'] > 0){
+                            obj['downBgpPeerCntText'] = ", <span class='text-error'>" +
+                                obj['downBgpPeerCnt'] + " Down</span>";
+                        } else {
+                            obj['downBgpPeerCntText'] = "";
+                        }
+                        obj['uveCfgIPMisMatch'] = false;
+                        if(obj['isUveMissing'] == false &&
+                                obj['isConfigMissing'] == false &&
+                                obj['isPartialUveMissing'] == false) {
+                            if(obj['uveIP'].indexOf(obj['configIP']) <= -1){
+                                obj['uveCfgIPMisMatch'] = true;
+                            }
+                        }
+                        obj['type'] = 'controlNode';
+                        obj['display_type'] = 'Control Node';
+                        var upTime = new XDate(jsonPath(d,'$..uptime')[0]/1000);
+                        var currTime = new XDate();
+                        var procStateList;
+                        try{
+                            obj['status'] = getOverallNodeStatus(d,"control");
+                        }catch(e){
+                            obj['status'] = 'Down';
+                        }
+                        obj['processAlerts'] =
+                            infraMonitorAlertUtils.getProcessAlerts(d,obj);
+                        obj['isGeneratorRetrieved'] = false;
+                        obj['nodeAlerts'] =
+                            infraMonitorAlertUtils.processControlNodeAlerts(obj);
+                        obj['alerts'] =
+                            obj['nodeAlerts'].concat(obj['processAlerts'])
+                                                .sort(dashboardUtils.sortInfraAlerts);
+                        obj['color'] = monitorInfraUtils.getControlNodeColor(d,obj);
+                        retArr.push(obj);
+                    });
+                    retArr.sort(dashboardUtils.sortNodesByColor);
+                    return retArr;
+
+                };
+
+              //Parser for analytics node dashboard data
+                this.parseAnalyticsNodesDashboardData = function (result) {
+
+                    var retArr = [];
+                    $.each(result, function(idx, d) {
+                        var obj = {};
+                        obj['x'] =
+                            parseFloat(jsonPath(d,'$..ModuleCpuState.module_cpu_info' +
+                            '[?(@.module_id=="contrail-collector")]..cpu_share')[0]);
+                        obj['y'] =
+                            parseInt(jsonPath(d,'$..ModuleCpuState.module_cpu_info' +
+                            '[?(@.module_id=="contrail-collector")]..meminfo.res')[0])
+                            / 1024;
+                        obj['cpu'] = $.isNumeric(obj['x']) ? obj['x'].toFixed(2) : '-';
+                        obj['memory'] = formatBytes(obj['y'] * 1024 * 1024);
+                        obj['x'] = $.isNumeric(obj['x']) ? obj['x'] : 0;
+                        obj['y'] = $.isNumeric(obj['y']) ? obj['y'] : 0;
+                        obj['histCpuArr'] =
+                            parseUveHistoricalValues(d,'$.cpuStats.history-10');
+                        obj['pendingQueryCnt'] = ifNull(jsonPath(d,
+                            '$..QueryStats.queries_being_processed')[0], []).length;
+                        obj['pendingQueryCnt'] = ifNull(jsonPath(d,
+                            '$..QueryStats.pending_queries')[0], []).length;
+                        obj['size'] = obj['pendingQueryCnt'] + 1;
+                        obj['shape'] = 'circle';
+                        obj['type'] = 'analyticsNode';
+                        obj['display_type'] = 'Analytics Node';
+                        obj['version'] = ifEmpty(self.getNodeVersion(jsonPath(d,
+                            '$.CollectorState.build_info')[0]), '-');
+                        try {
+                            obj['status'] = getOverallNodeStatus(d, "analytics");
+                        } catch(e) {
+                            obj['status'] = 'Down';
+                        }
+                        //get the ips
+                        var iplist = ifNull(jsonPath(d,'$..self_ip_list')[0],
+                           noDataStr);
+                        obj['ip'] = obj['summaryIps'] = noDataStr;
+                        if (iplist != null && iplist != noDataStr
+                           && iplist.length > 0) {
+                            obj['ip'] = iplist[0];
+                            var ipString = "";
+                            $.each(iplist, function(idx, ip) {
+                                if (idx + 1 == iplist.length) {
+                                    ipString = ipString + ip;
+                                } else {
+                                    ipString = ipString + ip + ', ';
+                                }
+                            });
+                            obj['summaryIps'] = ipString;
+                        }
+                        obj['name'] = d['name'];
+                        obj['link'] = {
+                            p : 'mon_infra_analytics',
+                            q : {
+                                node : obj['name'],
+                                tab : ''
+                            }
+                        };
+                        obj['errorStrings'] = ifNull(jsonPath(d,
+                            "$.value.ModuleCpuState.error_strings")[0], []);
+                        obj['isNTPUnsynced'] =
+                            isNTPUnsynced(jsonPath(d,'$..NodeStatus')[0]);
+                        var isConfigDataAvailable = $.isEmptyObject(jsonPath(d,
+                            '$..ConfigData')[0]) ? false : true;
+                        obj['isUveMissing'] =
+                            ($.isEmptyObject(jsonPath(d,'$..CollectorState')[0])
+                            && isConfigDataAvailable) ? true : false;
+                        obj['processAlerts'] =
+                            infraMonitorAlertUtils.getProcessAlerts(d, obj);
+                        obj['isPartialUveMissing'] = false;
+                        if (obj['isUveMissing'] == false) {
+                            if (isEmptyObject(jsonPath(d,
+                                '$.value.ModuleCpuState.module_cpu_info'+
+                                '[?(@.module_id=="contrail-collector")].cpu_info')[0])
+                                || isEmptyObject(jsonPath(d,
+                                        '$.value.CollectorState.build_info')[0])) {
+                                        obj['isPartialUveMissing'] = true;
+                            }
+                        }
+                        //get the cpu for analytics node
+                        var cpuInfo =
+                            jsonPath(d,'$..ModuleCpuState.module_cpu_info')[0];
+                        obj['isGeneratorRetrieved'] = false;
+                        var genInfos = ifNull(jsonPath(d,
+                            '$.value.CollectorState.generator_infos')[0], []);
+                        obj['genCount'] = genInfos.length;
+                        obj['nodeAlerts'] = infraMonitorAlertUtils
+                                                .processAnalyticsNodeAlerts(obj);
+                        obj['alerts'] = obj['nodeAlerts'].concat(obj['processAlerts'])
+                                            .sort(dashboardUtils.sortInfraAlerts);
+                        obj['color'] = monitorInfraUtils.getAnalyticsNodeColor(d, obj);
+                        retArr.push(obj);
+                    });
+                    retArr.sort(dashboardUtils.sortNodesByColor);
+                    return retArr;
+
+                };
+
+                this.parseConfigNodesDashboardData = function (result) {
+
+                    var retArr = [];
+                    $.each(result,function(idx,d) {
+                        var obj = {};
+                        obj['x'] = parseFloat(jsonPath(d,
+                            '$..ModuleCpuState.module_cpu_info'+
+                            '[?(@.module_id=="contrail-api")]..cpu_share')[0]);
+                        obj['y'] = parseInt(jsonPath(d,
+                            '$..ModuleCpuState.module_cpu_info'+
+                            '[?(@.module_id=="contrail-api")]..meminfo.res')[0])/1024;
+                        obj['cpu'] = $.isNumeric(obj['x']) ? obj['x'].toFixed(2) : '-';
+                        obj['memory'] = formatBytes(obj['y']*1024*1024);
+                        obj['x'] = $.isNumeric(obj['x']) ? obj['x'] : 0;
+                        obj['y'] = $.isNumeric(obj['y']) ? obj['y'] : 0;
+                        //Re-visit once average response time added for config nodes
+                        obj['size'] = 1;
+                        obj['version'] = ifEmpty(self.getNodeVersion(jsonPath(d,
+                            '$.value.configNode.ModuleCpuState.build_info')[0]),'-');
+                        obj['shape'] = 'circle';
+                        obj['type'] = 'configNode';
+                        obj['display_type'] = 'Config Node';
+                        obj['name'] = d['name'];
+                        obj['link'] =
+                            {p:'mon_infra_config',q:{node:obj['name'],tab:''}};
+                        obj['isNTPUnsynced'] =
+                            isNTPUnsynced(jsonPath(d,'$..NodeStatus')[0]);
+                        obj['isConfigMissing'] =
+                            $.isEmptyObject(getValueByJsonPath(d,
+                                                    'value;ConfigData')) ? true : false;
+                        obj['isUveMissing'] =
+                            ($.isEmptyObject(getValueByJsonPath(d,'value;configNode')))
+                                ? true : false;
+                        obj['processAlerts'] =
+                            infraMonitorAlertUtils.getProcessAlerts(d,obj);
+                        obj['isPartialUveMissing'] = false;
+                        try{
+                            obj['status'] = getOverallNodeStatus(d,"config");
+                        }catch(e){
+                            obj['status'] = 'Down';
+                        }
+                        obj['histCpuArr'] =
+                            parseUveHistoricalValues(d,'$.cpuStats.history-10');
+                        var iplist = jsonPath(d,'$..config_node_ip')[0];
+                        obj['ip'] = obj['summaryIps'] = noDataStr;
+                        if(iplist != null && iplist != noDataStr && iplist.length > 0){
+                        obj['ip'] = iplist[0];
+                        var ipString = "";
+                            $.each(iplist, function (idx, ip){
+                                if(idx+1 == iplist.length) {
+                                    ipString = ipString + ip;
+                                   } else {
+                                    ipString = ipString + ip + ', ';
+                                   }
+                            });
+                            obj['summaryIps'] = ipString;
+                        }
+                        if(isEmptyObject(jsonPath(d,
+                           '$.value.configNode.ModuleCpuState.module_cpu_info'+
+                           '[?(@.module_id=="contrail-api")].cpu_info')[0]) ||
+                           isEmptyObject(jsonPath(d,
+                                '$.value.configNode.ModuleCpuState.build_info')[0])) {
+                           obj['isPartialUveMissing'] = true;
+                        }
+                        obj['isGeneratorRetrieved'] = false;
+                        obj['nodeAlerts'] =
+                            infraMonitorAlertUtils.processConfigNodeAlerts(obj);
+                        obj['alerts'] =
+                            obj['nodeAlerts'].concat(obj['processAlerts'])
+                                .sort(dashboardUtils.sortInfraAlerts);
+                        obj['color'] = monitorInfraUtils.getConfigNodeColor(d,obj);
+                        retArr.push(obj);
+                    });
+                    retArr.sort(dashboardUtils.sortNodesByColor);
+                    return retArr;
+
+                };
+
+                //Parser for DBNode
+                this.parseDatabaseNodesDashboardData = function (result) {
+
+                    var retArr = [];
+                    $.each(result,function(idx,d) {
+                        var obj = {};
+                        var dbSpaceAvailable =
+                            parseFloat(jsonPath(d,
+                            '$.value.databaseNode.DatabaseUsageInfo.'+
+                            'database_usage[0].disk_space_available_1k')[0]);
+                        var dbSpaceUsed = parseFloat(jsonPath(d,
+                            '$.value.databaseNode.DatabaseUsageInfo.'+
+                            'database_usage[0].disk_space_used_1k')[0]);
+                        var analyticsDbSize = parseFloat(jsonPath(d,
+                            '$.value.databaseNode.DatabaseUsageInfo.'+
+                            'database_usage[0].analytics_db_size_1k')[0]);
+
+                        obj['x'] = $.isNumeric(dbSpaceAvailable)?
+                            dbSpaceAvailable / 1024 / 1024 : 0;
+                        obj['y'] = $.isNumeric(dbSpaceUsed)?
+                            dbSpaceUsed / 1024 / 1024 : 0;
+
+                        obj['isConfigMissing'] = $.isEmptyObject(getValueByJsonPath(d,
+                            'value;ConfigData')) ? true : false;
+                        obj['isUveMissing'] = ($.isEmptyObject(getValueByJsonPath(d,
+                            'value;databaseNode'))) ? true : false;
+                        var configData;
+                        if(!obj['isConfigMissing']){
+                            configData = getValueByJsonPath(d,'value;ConfigData');
+                            obj['ip'] = configData.database_node_ip_address;
+                        } else {
+                            obj['ip'] = noDataStr;
+                        }
+                        obj['dbSpaceAvailable'] = dbSpaceAvailable;
+                        obj['dbSpaceUsed'] = dbSpaceUsed;
+                        obj['analyticsDbSize'] = analyticsDbSize;
+                        obj['formattedAvailableSpace'] = $.isNumeric(dbSpaceAvailable)?
+                            formatBytes(dbSpaceAvailable * 1024) : '-';
+                        obj['formattedUsedSpace'] = $.isNumeric(dbSpaceUsed)?
+                            formatBytes(dbSpaceUsed * 1024) : '-';
+                        //Use the db usage percentage for bubble size
+                        var usedPercentage = (obj['y'] * 100) / (obj['y']+obj['x']);
+                        obj['usedPercentage'] = usedPercentage;
+                        obj['formattedUsedPercentage'] = $.isNumeric(usedPercentage)?
+                                usedPercentage.toFixed(2) + ' %': '-' ;
+                        obj['formattedAnalyticsDbSize'] = $.isNumeric(analyticsDbSize)?
+                            formatBytes(analyticsDbSize * 1024) : '-';
+                        obj['formattedUsedSpaceWithPercentage'] =
+                            (obj['formattedUsedSpace'] != '-')?
+                            obj['formattedUsedSpace']  + ' (' +
+                            obj['formattedUsedPercentage'] + ')' :
+                                '-';
+                        obj['size'] = obj['usedPercentage']  ;
+                        obj['shape'] = 'circle';
+                        obj['type'] = 'dbNode';
+                        obj['display_type'] = 'Database Node';
+                        obj['name'] = d['name'];
+                        obj['link'] = {p:'mon_infra_database',
+                            q:{node:obj['name'],tab:''}};
+                        obj['processAlerts'] =
+                            infraMonitorAlertUtils.getProcessAlerts(d,obj);
+                        obj['isPartialUveMissing'] = false;
+                        try{
+                            obj['status'] = getOverallNodeStatus(d,"db");
+                        }catch(e){
+                            obj['status'] = 'Down';
+                        }
+                        obj['isNTPUnsynced'] =
+                            isNTPUnsynced(jsonPath(d,'$..NodeStatus')[0]);
+                        obj['nodeAlerts'] =
+                            infraMonitorAlertUtils.processDbNodeAlerts(obj);
+                        obj['alerts'] = obj['nodeAlerts'].concat(obj['processAlerts'])
+                            .sort(dashboardUtils.sortInfraAlerts);
+                        obj['color'] = monitorInfraUtils.getDatabaseNodeColor(d,obj);
+                        retArr.push(obj);
+                    });
+                    retArr.sort(dashboardUtils.sortNodesByColor);
+                    return retArr;
+
+                }
+                this.getNodeVersion = function (buildStr) {
+                    var verStr = '';
+                    if(buildStr != null) {
+                        var buildInfo;
+                        try {
+                             buildInfo = JSON.parse(buildStr);
+                        } catch(e) {
+                        }
+                        if((buildInfo != null) && (buildInfo['build-info'] instanceof Array)) {
+                            var buildObj = buildInfo['build-info'][0];
+                            verStr = buildObj['build-version'] + ' (Build ' + buildObj['build-number'] + ')'
+                        }
+                    }
+                    return verStr;
+                };
+            };
+
+            return MonInfraParsers;
+       }
+);

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils.js
@@ -1,0 +1,372 @@
+define([
+    'underscore',
+    'contrail-list-model'
+], function (_, ContrailListModel) {
+    var MonitorInfraUtils = function () {
+        var self = this;
+        self.getNodeColor = function (obj) {
+            obj = ifNull(obj,{});
+            //Check if there is any nodeAlert and if yes,
+            //get the highest severity alert
+            var nodeAlertSeverity = -1,processLevelSeverity = -1;
+            if(obj['nodeAlerts'].length > 0) {
+                nodeAlertSeverity = obj['nodeAlerts'][0]['sevLevel'];
+            }
+            //Check if any process Alerts
+            if(obj['processAlerts'].length > 0) {
+                processLevelSeverity = obj['processAlerts'][0]['sevLevel'];
+            }
+            if(nodeAlertSeverity == sevLevels['ERROR'] ||
+                    processLevelSeverity == sevLevels['ERROR'])
+                return ctwc.COLOR_SEVERITY_MAP['red'];
+            if(nodeAlertSeverity == sevLevels['WARNING'] ||
+                    processLevelSeverity == sevLevels['WARNING'])
+                return ctwc.COLOR_SEVERITY_MAP['orange'];
+            return false;
+        };
+
+        self.getConfigNodeColor = function (d,obj) {
+            obj= ifNull(obj,{});
+            var nodeColor = self.getNodeColor(obj);
+            if(nodeColor != false)
+                return nodeColor;
+            return ctwc.COLOR_SEVERITY_MAP['blue'];
+        };
+
+        self.getControlNodeColor = function (d,obj) {
+            obj= ifNull(obj,{});
+            var nodeColor = self.getNodeColor(obj);
+            if(nodeColor != false)
+                return nodeColor;
+            //If connected to atleast one XMPP Peer
+            if(obj['totalXMPPPeerCnt'] - obj['downXMPPPeerCnt'] > 0)
+                return ctwc.COLOR_SEVERITY_MAP['green'];
+            else if(obj['downBgpPeerCnt'] == 0 && obj['downXMPPPeerCnt'] == 0)
+                return ctwc.COLOR_SEVERITY_MAP['blue'];    //Default color
+        };
+
+        self.getDatabaseNodeColor = function (d,obj) {
+            obj= ifNull(obj,{});
+            var nodeColor = self.getNodeColor(obj);
+            if(nodeColor != false)
+                return nodeColor;
+            return ctwc.COLOR_SEVERITY_MAP['blue'];
+        };
+
+        self.getAnalyticsNodeColor = function (d, obj) {
+            obj= ifNull(obj,{});
+            var nodeColor = self.getNodeColor(obj);
+            if(nodeColor != false)
+                return nodeColor;
+            return ctwc.COLOR_SEVERITY_MAP['blue'];
+        };
+
+        self.getGeneratorsAjaxConfigForInfraNodes = function (dsName) {
+            var ajaxConfig = {};
+            var kfilts;
+            var cfilts;
+            if(dsName == 'controlNodeDS') {
+                kfilts =  '*:' + UVEModuleIds['CONTROLNODE'] + '*';
+                cfilts =  'ModuleClientState:client_info,'+
+                          'ModuleServerState:generator_info';
+            } else if(dsName == 'computeNodeDS') {
+                //Handling the case module id will change for the TOR agent/ TSN
+                //We need to send all the module ids if different
+                var items = dataSource.getItems();
+                var kfiltString = ""
+                var moduleIds = [];
+                $.each(items,function(i,d){
+                    if(moduleIds.indexOf(d['moduleId']) == -1){
+                        moduleIds.push(d['moduleId']);
+                        //Exclude getting contrail-tor-agent generators
+                        if(d['moduleId'] == 'contrail-tor-agent') {
+                            return;
+                        }
+                        if(kfiltString != '')
+                            kfiltString += ',';
+                        kfiltString += '*:' + d['moduleId'] + '*';
+                    }
+                });
+                kfilts =  kfiltString;
+                cfilts = 'ModuleClientState:client_info,'+
+                         'ModuleServerState:generator_info';
+            } else if(dsName == 'analyticsNodeDS') {
+                kfilts = '*:' + UVEModuleIds['COLLECTOR'] + '*,*:' +
+                                UVEModuleIds['OPSERVER'] + '*,*:' +
+                                UVEModuleIds['QUERYENGINE'] + '*';
+                cfilts = 'ModuleClientState:client_info,'+
+                         'ModuleServerState:generator_info';
+            } else if(dsName == 'configNodeDS') {
+                kfilts = '*:' + UVEModuleIds['APISERVER'] + '*';
+                cfilts = 'ModuleClientState:client_info,'+
+                         'ModuleServerState:generator_info';
+            }
+
+            var postData = getPostData("generator",'','',cfilts,kfilts);
+
+            ajaxConfig = {
+                    url:TENANT_API_URL,
+                    type:'POST',
+                    data:JSON.stringify(postData)
+                };
+            return ajaxConfig;
+        };
+
+        self.parseInfraGeneratorsData = function(result) {
+            var retArr = [];
+            if(result != null && result[0] != null){
+                result = result[0].value;
+            } else {
+                result = [];
+            }
+            $.each(result,function(idx,d){
+                var obj = {};
+                obj['status'] = self.getOverallNodeStatusFromGenerators(d);
+                obj['name'] = d['name'];
+                retArr.push(obj);
+            });
+            return retArr;
+        };
+
+        self.getOverallNodeStatusFromGenerators = function () {
+            var status = "--";
+            var generatorDownTime;
+
+
+            // For each process get the generator_info and fetch the gen_attr
+            // which is having the highest connect_time. This is because
+            // we are interseted only in the collector this is connected
+            // to the latest.
+
+            // From this gen_attr see if the reset_time > connect_time.
+
+            // If yes then the process is down track it in down list.
+            // Else it is up and track in uplist.
+
+            // If any of the process is down get the least reset_time
+            // from the down list and display the node as down.
+
+            // Else get the generator with max connect_time and
+            // show the status as Up.
+            try{
+                var genInfos = ifNull(jsonPath(d,
+                    "$..ModuleServerState..generator_info"),[]);
+                if(!genInfos){
+                    return 'Down';
+                }
+                var upGenAttrs = [];
+                var downGenAttrs = [];
+                var isDown = false;
+                $.each(genInfos,function(idx,genInfo){
+                    var genAttr =
+                        getMaxGeneratorValueInArray(genInfo,"connect_time");
+                    var connTime = jsonPath(genAttr,"$..connect_time")[0];
+                    var resetTime = jsonPath(genAttr,"$..reset_time")[0];
+                    if(resetTime > connTime){
+                        isDown = true;
+                        downGenAttrs.push(genAttr);
+                    } else {
+                        upGenAttrs.push(genAttr);
+                    }
+                });
+                if(!isDown){
+                    var maxConnTimeGen =
+                        getMaxGeneratorValueInArray(upGenAttrs,"connect_time");
+                    var maxConnTime =
+                        jsonPath(maxConnTimeGen,"$..connect_time")[0];
+                    var connectTime = new XDate(maxConnTime/1000);
+                    var currTime = new XDate();
+                    status = 'Up since ' + diffDates(connectTime,currTime);
+                } else {
+                    var minResetTimeGen =
+                        getMinGeneratorValueInArray(downGenAttrs,"reset_time");
+                    var minResetTime =
+                        jsonPath(minResetTimeGen,"$..reset_time")[0];
+                    var resetTime = new XDate(minResetTime/1000);
+                    var currTime = new XDate();
+                    status = 'Down since ' + diffDates(resetTime,currTime);
+                }
+            }catch(e){}
+
+            return status;
+        };
+
+        self.parseAndMergeGeneratorWithPrimaryDataForInfraNodes =
+            function(response, primaryDS) {
+
+            var genDSData = self.parseInfraGeneratorsData(response);
+            var primaryData = primaryDS.getItems();
+            var updatedData = [];
+            // to avoid the change event getting triggered
+            // copy the data into another array and use it.
+            var genData = [];
+            $.each(genDSData,function (idx,obj){
+                genData.push(obj);
+            });
+            $.each(primaryData,function(i,d){
+                var idx=0;
+                while(genData.length > 0 && idx < genData.length){
+                    if(genData[idx]['name'].split(':')[0] == d['name']){
+                        d['status'] = getFinalNodeStatusFromGenerators(
+                           genData[idx]['status'],primaryData[i]);
+                        d['isGeneratorRetrieved'] = true;
+                        genData.splice(idx,1);
+                        break;
+                    }
+                    idx++;
+                };
+                updatedData.push(d);
+            });
+            primaryDS.updateData(updatedData);
+        };
+
+        // This function accepts the node data and returns the alerts
+        // array which need to displayed in chart tooltip.
+        self.getTooltipAlerts = function (data) {
+            var tooltipAlerts = [];
+            if (ifNull(data['alerts'],[]).length > 0) {
+               $.each(data['alerts'],function(idx,obj){
+                  if(obj['tooltipAlert'] != false)
+                      tooltipAlerts.push({
+                          label : 'Events',
+                          value : ifNull(obj['msg'],"")
+                      });
+               });
+            }
+            return tooltipAlerts;
+        };
+
+        //Utility get the process uptime given process data
+        self.getProcessUpTime = function (d) {
+            var upTimeStr = noDataStr;
+            if(d != null && d.process_state != null &&
+                    d.process_state.toUpperCase() == "PROCESS_STATE_RUNNING") {
+                if(d.last_start_time != null){
+                    var upTime = new XDate(d.last_start_time/1000);
+                    var currTime = new XDate();
+                    upTimeStr = 'Up since ' + diffDates(upTime,currTime);
+                }
+            } else {
+                var exitTime=0,stopTime=0;
+                var currTime = new XDate();
+                if(d.last_exit_time != null){
+                    exitTime = d.last_exit_time;
+                }
+                if(d.last_stop_time != null){
+                    stopTime = d.last_stop_time;
+                }
+                if(exitTime != 0 || stopTime != 0){
+                    if(exitTime > stopTime){
+                        exitTime = new XDate(exitTime/1000);
+                        upTimeStr = 'Down since ' + diffDates(exitTime,currTime);
+                    } else {
+                        stopTime = new XDate(stopTime/1000);
+                        upTimeStr = 'Down since ' + diffDates(stopTime,currTime);
+                    }
+                } else {
+                    upTimeStr = "Down";
+                }
+            }
+            return upTimeStr;
+        };
+
+        /*
+         * Common function to retrieve the analytics messages count and size
+         */
+        self.getAnalyticsMessagesCountAndSize = function (d,procList){
+            var count = 0,size = 0, obj = {};
+            for(var key in d){
+                var label = key.toUpperCase();
+                $.each(procList,function(idx,proc){
+                    if(label.indexOf(":"+proc.toUpperCase()+":") != -1){
+                        obj[key] = d[key];
+                    }
+                });
+            }
+            var sizes =  ifNull(jsonPath(obj,"$..ModuleClientState.client_info.tx_socket_stats.bytes"),0);
+            var counts = ifNull(jsonPath(obj,"$..ModuleClientState.session_stats.num_send_msg"),0);
+            $.each(counts,function(i,cnt){
+                count += cnt;
+            });
+            $.each(sizes,function(i,sze){
+                size += sze;
+            });
+            return {count:count,size:size};
+        }
+
+        //Given the data and the node type get the last log time stamp for the node
+        self.getLastLogTimestamp = function (d, nodeType){
+            var logLevelStats = [], lastLog, lastTimeStamp;
+            var procsList = [];
+            if(nodeType != null){
+                if(nodeType == "control"){
+                    procsList = monitorInfraConstants.controlProcsForLastTimeStamp;
+                } else if (nodeType == "compute"){
+                    var proces = getValueByJsonPath(d,'NodeStatus;process_status;0;module_id');
+                    if(proces != null){
+                        procsList = [proces];
+                    } else {
+                        procsList = monitorInfraConstants.computeProcsForLastTimeStamp;
+                    }
+                } else if (nodeType =="analytics") {
+                    procsList = monitorInfraConstants.analyticsProcsForLastTimeStamp;
+                } else if (nodeType =="config"){
+                    procsList = monitorInfraConstants.configProcsForLastTimeStamp;
+                }
+                $.each(procsList,function(idx,proc){
+                    logLevelStats = getAllLogLevelStats(d,proc,logLevelStats);
+                });
+            } else {
+                logLevelStats = getAllLogLevelStats(d,"",logLevelStats);
+            }
+
+            if(logLevelStats != null){
+                lastLog = getMaxGeneratorValueInArray(logLevelStats,"last_msg_timestamp");
+                if(lastLog != null){
+                    lastTimeStamp = lastLog.last_msg_timestamp;
+                }
+            }
+            return lastTimeStamp;
+        }
+
+        /**
+         * Function returns the overall node status html of monitor infra node details page
+         */
+        self.getOverallNodeStatusForDetails = function (data){
+            var statusObj = this.getNodeStatusForSummaryPages(data);
+            var templateData = {result:statusObj['alerts'],showMore:true,defaultItems:1};
+            return contrail.getTemplate4Id('overallNodeStatusTemplate')(templateData);
+        }
+
+        /**
+         * This function takes parsed nodeData from the infra parse functions and returns object with all alerts displaying in dashboard tooltip,
+         * and tooltip messages array
+         */
+        self.getNodeStatusForSummaryPages = function (data,page) {
+            var result = {},msgs = [],tooltipAlerts = [];
+            for(var i = 0;i < data['alerts'].length; i++) {
+                if(data['alerts'][i]['tooltipAlert'] != false) {
+                    tooltipAlerts.push(data['alerts'][i]);
+                    msgs.push(data['alerts'][i]['msg']);
+                }
+            }
+            //Status is pushed to messages array only if the status is "UP" and tooltip alerts(which are displaying in tooltip) are zero
+            if(ifNull(data['status'],"").indexOf('Up') > -1 && tooltipAlerts.length == 0) {
+                msgs.push(data['status']);
+                tooltipAlerts.push({msg:data['status'],sevLevel:sevLevels['INFO']});
+            } else if(ifNull(data['status'],"").indexOf('Down') > -1) {
+                //Need to discuss and add the down status
+                //msgs.push(data['status']);
+                //tooltipAlerts.push({msg:data['status'],sevLevel:sevLevels['ERROR']})
+            }
+            result['alerts'] = tooltipAlerts;
+            result['nodeSeverity'] = data['alerts'][0] != null ? data['alerts'][0]['sevLevel'] : sevLevels['INFO'];
+            result['messages'] = msgs;
+             var statusTemplate = contrail.getTemplate4Id('statusTemplate');
+            if(page == 'summary')
+                return statusTemplate({sevLevel:result['nodeSeverity'],sevLevels:sevLevels});
+            return result;
+        }
+    };
+    return MonitorInfraUtils;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/views/AnalyticsNodeScatterChartView.js
+++ b/webroot/monitor/infrastructure/common/ui/js/views/AnalyticsNodeScatterChartView.js
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(['underscore', 'contrail-view'],function(_, ContrailView){
+   var AnalyticsNodeScatterChartView = ContrailView.extend({
+                                       render : function (){
+                                           this.renderView4Config(this.$el,
+                                           this.model,
+                                           getConfigNodeScatterChartViewConfig()
+                                           );
+                                       }
+                                    });
+
+   function getConfigNodeScatterChartViewConfig() {
+       return {
+           elementId : ctwl.ANALYTICSNODE_SUMMARY_SCATTERCHART_SECTION_ID,
+           view : "SectionView",
+           viewConfig : {
+               rows : [ {
+                   columns : [ {
+                       elementId : ctwl.ANALYTICSNODE_SUMMARY_SCATTERCHART_ID,
+                       title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                       view : "ZoomScatterChartView",
+                       viewConfig : {
+                           loadChartInChunks : true,
+                           chartOptions : {
+                               xLabel : 'CPU (%)',
+                               yLabel : 'Memory (MB)',
+                               forceX : [ 0, 1 ],
+                               forceY : [ 0, 20 ],
+                               dataParser : function(
+                                       response) {
+                                   var chartDataValues = [ ];
+                                   for ( var i = 0; i < response.length; i++) {
+                                       var analyticsNode = response[i];
+                                       chartDataValues
+                                           .push({
+                                               name : analyticsNode['name'],
+                                               y : analyticsNode['y'],
+                                               x : contrail.handleIfNull(
+                                                   analyticsNode['x'],
+                                                   0),
+                                               color : analyticsNode['color'],
+                                               size : contrail.handleIfNull(
+                                                   analyticsNode['size'],
+                                                   0),
+                                               rawData : analyticsNode
+                                           });
+                                   }
+                                   return chartDataValues;
+                               },
+                               tooltipConfigCB : getAnalyticsNodeTooltipConfig,
+                               controlPanelConfig: {
+                                   legend: {
+                                       enable: true,
+                                       viewConfig: getControlPanelLegendConfig()
+                                   }
+                               },
+                               clickCB : onScatterChartClick
+                           }
+                       }
+                   } ]
+               } ]
+           }
+       };
+
+       function onScatterChartClick(chartConfig) {
+           var analyticsNode = chartConfig.name, hashObj = {
+               node : analyticsNode,
+               tab : ''
+           };
+
+           layoutHandler.setURLHashParams(hashObj, {
+               p : "mon_infra_analytics",
+               merge : false,
+               triggerHashChange : true
+           });
+       };
+
+       function getAnalyticsNodeTooltipConfig(data) {
+           var analyticsNode = data.rawData;
+           var tooltipData = [
+                              {
+                                  label : 'Version',
+                                  value : analyticsNode.version
+                              },
+                              {
+                                  label : 'CPU',
+                                  value : analyticsNode.cpu,
+                              },
+                              {
+                                  label : 'Memory',
+                                  value : analyticsNode.memory,
+                              }];
+           var tooltipAlerts = monitorInfraUtils.getTooltipAlerts(analyticsNode);
+           tooltipData = tooltipData.concat(tooltipAlerts);
+           var tooltipConfig = {
+               title : {
+                   name : data.name,
+                   type : 'Analytics Node'
+               },
+               content : {
+                   iconClass : false,
+                   info : tooltipData,
+                   actions : [ {
+                       type : 'link',
+                       text : 'View',
+                       iconClass : 'icon-external-link',
+                       callback : function(
+                               data) {
+                           var nodeName = data.name, hashObj = {
+                               node : nodeName,
+                               tab : ''
+                           };
+                           layoutHandler.setURLHashParams(hashObj, {
+                               p : "mon_infra_analytics",
+                               merge : false,
+                               triggerHashChange : true
+                           });
+                       }
+                   } ]
+               },
+               delay : cowc.TOOLTIP_DELAY
+           };
+
+           return tooltipConfig;
+       };
+
+       function getControlPanelLegendConfig() {
+           return {
+               groups : [ {
+                   id : 'by-node-color',
+                   title : 'Node Color',
+                   items : [{
+                       text : 'Errors in UVE', //TODO need to discuss the format
+                       labelCssClass : 'icon-circle warning',
+                       events : {
+                           click : function(
+                                   event) {
+                           }
+                       }
+                   },{
+                       text : infraAlertMsgs['UVE_MISSING']+ ' or ' +
+                       infraAlertMsgs['NTP_UNSYNCED_ERROR'],
+                       labelCssClass : 'icon-circle error',
+                       events : {
+                           click : function(
+                                   event) {
+                           }
+                       }
+                   } ]
+               }]
+           };
+       };
+   }
+   return AnalyticsNodeScatterChartView;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/views/ConfigNodeScatterChartView.js
+++ b/webroot/monitor/infrastructure/common/ui/js/views/ConfigNodeScatterChartView.js
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(['underscore', 'contrail-view'],function(_, ContrailView){
+   var ConfigNodeScatterChartView = ContrailView.extend({
+                                       render : function (){
+                                           this.renderView4Config(this.$el,
+                                           this.model,
+                                           getConfigNodeScatterChartViewConfig()
+                                           );
+                                       }
+                                    });
+
+   function getConfigNodeScatterChartViewConfig() {
+       return {
+           elementId : ctwl.CONFIGNODE_SUMMARY_SCATTERCHART_SECTION_ID,
+           view : "SectionView",
+           viewConfig : {
+               rows : [ {
+                   columns : [ {
+                       elementId : ctwl.CONFIGNODE_SUMMARY_SCATTERCHART_ID,
+                       title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                       view : "ZoomScatterChartView",
+                       viewConfig : {
+                           loadChartInChunks : true,
+                           chartOptions : {
+                               xLabel : 'CPU (%)',
+                               yLabel : 'Memory (MB)',
+                               forceX : [ 0, 1 ],
+                               forceY : [ 0, 20 ],
+                               dataParser : function(
+                                       response) {
+                                   var chartDataValues = [ ];
+                                   for ( var i = 0; i < response.length; i++) {
+                                       var configNode = response[i];
+
+                                       chartDataValues
+                                               .push({
+                                                   name : configNode['name'],
+                                                   y : configNode['y'],
+                                                   x : contrail.handleIfNull(
+                                                       configNode['x'],
+                                                       0),
+                                                   color : configNode['color'],
+                                                   size : contrail.handleIfNull(
+                                                       configNode['size'],
+                                                       0),
+                                                   rawData : configNode
+                                               });
+                                   }
+                                   return chartDataValues;
+                               },
+                               tooltipConfigCB : getConfigNodeTooltipConfig,
+                               controlPanelConfig: {
+                                   legend: {
+                                       enable: true,
+                                       viewConfig: getControlPanelLegendConfig()
+                                   }
+                               },
+                               clickCB : onScatterChartClick
+                           }
+                       }
+                   } ]
+               } ]
+           }
+       };
+
+       function onScatterChartClick(
+               chartConfig) {
+           var configNodeName = chartConfig.name, hashObj = {
+               name : configNodeName,
+               tab : ''
+           };
+
+           layoutHandler.setURLHashParams(hashObj, {
+               p : "monitor_infra_config",
+               merge : false,
+               triggerHashChange : true
+           });
+       };
+
+       function getConfigNodeTooltipConfig(
+               data) {
+           var configNode = data.rawData;
+           var tooltipData = [
+                              {
+                                  label : 'Version',
+                                  value : configNode.version
+                              },
+                              {
+                                  label : 'CPU',
+                                  value : configNode.cpu,
+                              },
+                              {
+                                  label : 'Memory',
+                                  value : configNode.memory,
+                              }];
+           var tooltipAlerts = monitorInfraUtils.getTooltipAlerts(configNode);
+           tooltipData = tooltipData.concat(tooltipAlerts);
+           var tooltipConfig = {
+               title : {
+                   name : data.name,
+                   type : 'Config Node'
+               },
+               content : {
+                   iconClass : false,
+                   info : tooltipData,
+                   actions : [ {
+                       type : 'link',
+                       text : 'View',
+                       iconClass : 'icon-external-link',
+                       callback : function(
+                               data) {
+                           var nodeName = data.name, hashObj = {
+                               node : nodeName
+                           };
+                           layoutHandler.setURLHashParams(hashObj, {
+                               p : "mon_infra_config",
+                               merge : false,
+                               triggerHashChange : true
+                           });
+                       }
+                   } ]
+               },
+               delay : cowc.TOOLTIP_DELAY
+           };
+
+           return tooltipConfig;
+       };
+
+       function getControlPanelLegendConfig() {
+           return {
+               groups : [{
+                   id : 'by-node-color',
+                   title : 'Node Color',
+                   items : [{
+                       text : infraAlertMsgs['UVE_MISSING']+ ' or ' +
+                           infraAlertMsgs['NTP_UNSYNCED_ERROR'],
+                       labelCssClass : 'icon-circle error',
+                       events : {
+                           click : function(
+                               event) {
+                       }
+                   }
+                   }]
+               }]
+           };
+       };
+   }
+   return ConfigNodeScatterChartView;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/views/ControlNodeScatterChartView.js
+++ b/webroot/monitor/infrastructure/common/ui/js/views/ControlNodeScatterChartView.js
@@ -1,0 +1,164 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(['underscore', 'contrail-view'],function(_, ContrailView){
+   var ControlNodeScatterChartView = ContrailView.extend({
+                                       render : function (){
+                                           this.renderView4Config(this.$el,
+                                           this.model,
+                                           getControlNodeScatterChartViewConfig()
+                                           );
+                                       }
+                                    });
+
+   function getControlNodeScatterChartViewConfig() {
+       return {
+           elementId : ctwl.CONTROLNODE_SUMMARY_SCATTERCHART_SECTION_ID,
+           view : "SectionView",
+           viewConfig : {
+               rows : [ {
+                   columns : [ {
+                       elementId : ctwl.CONTROLNODE_SUMMARY_SCATTERCHART_ID,
+                       title : ctwl.CONTROLNODE_SUMMARY_TITLE,
+                       view : "ZoomScatterChartView",
+                       viewConfig : {
+                           loadChartInChunks : true,
+                           chartOptions : {
+                               xLabel : 'CPU (%)',
+                               yLabel : 'Memory (MB)',
+                               forceX : [ 0, 1 ],
+                               forceY : [ 0, 20 ],
+                               dataParser : function(
+                                       response) {
+                                   var chartDataValues = [ ];
+                                   for ( var i = 0; i < response.length; i++) {
+                                       var controlNode = response[i];
+
+                                       chartDataValues
+                                               .push({
+                                                   name : controlNode['name'],
+                                                   y : controlNode['y'],
+                                                   x : contrail.handleIfNull(
+                                                       controlNode['x'],
+                                                       0),
+                                                   color : controlNode['color'],
+                                                   size : contrail.handleIfNull(
+                                                       controlNode['size'],
+                                                       0),
+                                                   rawData : controlNode
+                                               });
+                                   }
+                                   return chartDataValues;
+                               },
+                               tooltipConfigCB : getControlNodeTooltipConfig,
+                               controlPanelConfig: {
+                                   legend: {
+                                       enable: true,
+                                       viewConfig: getControlPanelLegendConfig()
+                                   }
+                               },
+                               clickCB : onScatterChartClick
+                           }
+                       }
+                   } ]
+               } ]
+           }
+       };
+
+       function onScatterChartClick(
+               chartConfig) {
+           var controlNodeName = chartConfig.name, hashObj = {
+               name : controlNodeName,
+               tab : ''
+           };
+
+           layoutHandler.setURLHashParams(hashObj, {
+               p : "monitor_infra_control",
+               merge : false,
+               triggerHashChange : true
+           });
+       };
+
+       function getControlNodeTooltipConfig(
+               data) {
+           var controlNode = data.rawData;
+           var tooltipData = [
+                              {
+                                  label : 'Version',
+                                  value : controlNode.version
+                              },
+                              {
+                                  label : 'CPU',
+                                  value : controlNode.cpu,
+                              },
+                              {
+                                  label : 'Memory',
+                                  value : controlNode.memory,
+                              }];
+           var tooltipAlerts = monitorInfraUtils.getTooltipAlerts(controlNode);
+           tooltipData = tooltipData.concat(tooltipAlerts);
+           var tooltipConfig = {
+               title : {
+                   name : data.name,
+                   type : 'Control Node'
+               },
+               content : {
+                   iconClass : false,
+                   info : tooltipData,
+                   actions : [ {
+                       type : 'link',
+                       text : 'View',
+                       iconClass : 'icon-external-link',
+                       callback : function(
+                               data) {
+                           var nodeName = data.name, hashObj = {
+                               node : nodeName
+                           };
+                           layoutHandler.setURLHashParams(hashObj, {
+                               p : "mon_infra_control",
+                               merge : false,
+                               triggerHashChange : true
+                           });
+                       }
+                   } ]
+               },
+               delay : cowc.TOOLTIP_DELAY
+           };
+
+           return tooltipConfig;
+       };
+
+       function getControlPanelLegendConfig() {
+           return {
+               groups : [{
+                   id : 'by-node-color',
+                   title : 'Cluster Color',
+                   items : [ {
+                       text : infraAlertMsgs['UVE_MISSING'] + ' or ' +
+                           infraAlertMsgs['CONFIG_MISSING'] + ' or ' +
+                           infraAlertMsgs['CONFIG_IP_MISMATCH'] + ' or ' +
+                           infraAlertMsgs['IFMAP_DOWN'] + ' or ' +
+                           infraAlertMsgs['NTP_UNSYNCED_ERROR'],
+                       labelCssClass : 'icon-circle error',
+                       events : {
+                           click : function(
+                                   event) {
+                           }
+                       }
+                   },{
+                       text : 'XMPP peer down or BGP peer down ' +
+                           infraAlertMsgs['BGP_CONFIG_MISMATCH'],
+                       labelCssClass : 'icon-circle warning',
+                       events : {
+                           click : function(
+                                   event) {
+                           }
+                       }
+                   }]
+               }]
+           };
+       };
+   }
+   return ControlNodeScatterChartView;
+});

--- a/webroot/monitor/infrastructure/common/ui/js/views/DatabaseNodeScatterChartView.js
+++ b/webroot/monitor/infrastructure/common/ui/js/views/DatabaseNodeScatterChartView.js
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(['underscore', 'contrail-view'],function(_, ContrailView){
+   var DatabaseNodeScatterChartView = ContrailView.extend({
+                                       render : function (){
+                                           this.renderView4Config(this.$el,
+                                           this.model,
+                                           getDatabaseNodeScatterChartViewConfig());
+                                       }
+                                    });
+
+   function getDatabaseNodeScatterChartViewConfig() {
+       return {
+           elementId : ctwl.DATABASENODE_SUMMARY_SCATTERCHART_SECTION_ID,
+           view : "SectionView",
+           viewConfig : {
+               rows : [ {
+                   columns : [ {
+                       elementId : ctwl.DATABASENODE_SUMMARY_SCATTERCHART_ID,
+                       title : ctwl.DATABASENODE_SUMMARY_TITLE,
+                       view : "ZoomScatterChartView",
+                       viewConfig : {
+                           loadChartInChunks : true,
+                           chartOptions : {
+                               xLabel : 'Available Space (GB)',
+                               yLabel : 'Used Space (GB)',
+                               forceX : [ 0, 1 ],
+                               forceY : [ 0, 20 ],
+                               dataParser : function(
+                                       response) {
+                                   var chartDataValues = [ ];
+                                   for ( var i = 0; i < response.length; i++) {
+                                       var analyticsNode = response[i];
+
+                                       chartDataValues
+                                               .push({
+                                                   name : analyticsNode['name'],
+                                                   y : analyticsNode['y'],
+                                                   x : contrail.handleIfNull(
+                                                       analyticsNode['x'],
+                                                       0),
+                                                   color :
+                                                       analyticsNode['color'],
+                                                   size : contrail.handleIfNull(
+                                                       analyticsNode['size'],
+                                                       0),
+                                                   rawData : analyticsNode
+                                               });
+                                   }
+                                   return chartDataValues;
+                               },
+                               tooltipConfigCB : getDatabaseNodeTooltipConfig,
+                               controlPanelConfig: {
+                                   legend: {
+                                       enable: true,
+                                       viewConfig: getControlPanelLegendConfig()
+                                   }
+                               },
+                               clickCB : onScatterChartClick
+                           }
+                       }
+                   } ]
+               } ]
+           }
+       };
+
+       function onScatterChartClick(
+               chartConfig) {
+           var databaseNodeName = chartConfig.name, hashObj = {
+               node : databaseNodeName
+           };
+
+           layoutHandler.setURLHashParams(hashObj, {
+               p : "monitor_infra_database",
+               merge : false,
+               triggerHashChange : true
+           });
+       };
+
+       function getDatabaseNodeTooltipConfig(
+               data) {
+           var databaseNode = data.rawData;
+           var tooltipData = [
+              {
+                  label : 'Host Name',
+                  value : databaseNode['name']
+              },
+              {
+                  label : 'Disk Space',
+                  value : '',options:{noLabelColon:true}
+              },
+              {
+                  label : 'Available',
+                  value : databaseNode['formattedAvailableSpace']
+              },
+              {
+                  label : 'Used',
+                  value : databaseNode['formattedUsedSpace']
+              },
+              {
+                  label : 'Usage',
+                  value : databaseNode['formattedUsedPercentage']
+              },
+              {
+                  label : 'Analytics DB',
+                  value:'', options:{noLabelColon: true}
+              }
+           ];
+           var tooltipAlerts = monitorInfraUtils.getTooltipAlerts(databaseNode);
+           tooltipData = tooltipData.concat(tooltipAlerts);
+           var tooltipConfig = {
+               title : {
+                   name : data.name,
+                   type : 'Database Node'
+               },
+               content : {
+                   iconClass : false,
+                   info : tooltipData,
+                   actions : [ {
+                       type : 'link',
+                       text : 'View',
+                       iconClass : 'icon-external-link',
+                       callback : function(
+                               data) {
+                           var nodeName = data.name, hashObj = {
+                               node : nodeName
+                           };
+                           layoutHandler.setURLHashParams(hashObj, {
+                               p : "mon_infra_database",
+                               merge : false,
+                               triggerHashChange : true
+                           });
+                       }
+                   } ]
+               },
+               delay : cowc.TOOLTIP_DELAY
+           };
+
+           return tooltipConfig;
+       };
+
+       function getControlPanelLegendConfig() {
+           return {
+               groups : [ {
+                   id : 'by-node-color',
+                   title : 'Node Color',
+                   items : [ {
+                       text : 'Disk space usage warning',
+                       labelCssClass : 'icon-circle warning',
+                       events : {
+                           click : function(
+                                   event) {
+                           }
+                       }
+                   }, {
+                       text : infraAlertMsgs['UVE_MISSING'] + ' or ' +
+                       infraAlertMsgs['NTP_UNSYNCED_ERROR'] + ' or ' +
+                       'Disk space usage exceeds threshold',
+                       labelCssClass : 'icon-circle error',
+                       events : {
+                           click : function(
+                                   event) {
+                           }
+                       }
+                   } ]
+               }]
+           };
+       };
+   }
+   return DatabaseNodeScatterChartView;
+});

--- a/webroot/monitor/infrastructure/confignode/ui/js/confignode.main.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/confignode.main.js
@@ -1,0 +1,35 @@
+var configNodesLoader = new ConfigNodesLoader();
+
+function ConfigNodesLoader() {
+    this.load = function (paramObject) {
+        var self = this, currMenuObj = globalObj.currMenuObj,
+            hashParams = paramObject['hashParams'],
+            rootDir = currMenuObj['resources']['resource'][0]['rootDir'],
+            pathConfigNodeView = rootDir + '/js/views/ConfigNodeView.js',
+            renderFn = paramObject['renderFn'];
+
+        if (self.configNodeView == null) {
+            requirejs([pathConfigNodeView], function (ConfigNodeView) {
+                self.configNodeView = new ConfigNodeView();
+                self.renderView(renderFn, hashParams);
+            });
+        } else {
+            self.renderView(renderFn, hashParams);
+        }
+    };
+    this.renderView = function (renderFn, hashParams) {
+        $(contentContainer).html("");
+        if(hashParams.view == "details") {
+            this.configNodeView.renderConfigNodeDetails({hashParams: hashParams});
+        } else {
+            this.configNodeView.renderConfigNode({hashParams: hashParams});
+        }
+    };
+
+    this.updateViewByHash = function (hashObj, lastHashObj) {
+        this.load({hashParams : hashObj});
+    };
+
+    this.destroy = function () {
+    };
+}

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeDetailPageView.js
@@ -1,0 +1,289 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view',
+], function (_, ContrailView) {
+    var ConfigNodesDetailPageView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this;
+            var detailsTemplate = contrail.getTemplate4Id(
+                    cowc.TMPL_2COLUMN_1ROW_2ROW_CONTENT_VIEW);
+            var viewConfig = this.attributes.viewConfig;
+            var leftContainerElement = $('#left-column-container');
+            this.$el.html(detailsTemplate);
+
+            self.renderView4Config($('#left-column-container'), null,
+                    getConfigNodeDetailPageViewConfig(viewConfig));
+        }
+    });
+    var getConfigNodeDetailPageViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+        return {
+            elementId: ctwl.CONFIGNODE_DETAIL_PAGE_ID,
+            title: ctwl.TITLE_DETAILS,
+            view: "DetailsView",
+            viewConfig: {
+                ajaxConfig: {
+                    url: contrail.format(
+                            monitorInfraConstants.
+                            monitorInfraUrls['CONFIG_DETAILS'], hostname),
+                    type: 'GET'
+                },
+                templateConfig: getDetailsViewTemplateConfig(),
+                app: cowc.APP_CONTRAIL_CONTROLLER,
+                dataParser: function(result) {
+                    var configNodeData = result;
+                    var obj = monitorInfraParsers.
+                        parseConfigNodesDashboardData([result])[0];
+                    //Further parsing required for Details page done below
+
+                    var overallStatus;
+                    try{
+                        overallStatus = monitorInfraUtils.
+                            getOverallNodeStatusForDetails(obj);
+                    }catch(e){overallStatus = "<span> "+
+                        statusTemplate({sevLevel:sevLevels['ERROR'],
+                            sevLevels:sevLevels})+" Down</span>";
+                    }
+
+                    try{
+                        //Add the process status list with uptime
+                        var procStateList = jsonPath(configNodeData,
+                                "$..NodeStatus.process_info")[0];
+                        obj['configProcessStatusList'] =
+                            getStatusesForAllConfigProcesses(procStateList);
+                    }catch(e){}
+
+                    obj['name'] = hostname;
+
+                    obj['ips'] = getIpAddresses(result);
+
+                    obj['overAllStatus'] = overallStatus;
+
+                    obj['analyticsDetails'] = getAnalyticsNodeDetails(result);
+
+                    obj['lastLogTimestamp'] = getLastLogTime(result);
+                    return obj;
+                }
+            }
+        }
+    }
+
+    function getDetailsViewTemplateConfig() {
+        return {
+            title: 'Config Node',
+            templateGenerator: 'BlockListTemplateGenerator',
+            theme: 'widget-box',
+            keyClass: 'label-blue',
+            templateGeneratorConfig: getTemplateGeneratorConfig()
+        };
+    };
+
+    function getTemplateGeneratorConfig() {
+        var templateGeneratorConfig = [];
+        templateGeneratorConfig = templateGeneratorConfig.concat([
+                {
+                    key: 'name',
+                    label:'Hostname',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'ips',
+                    label:'IP Address',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'version',
+                    label: 'Version',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'overAllStatus',
+                    label: 'Overall Node Status',
+                    templateGenerator: 'TextGenerator'
+                }
+        ]);
+        //Add proccesses info only if the node manager is installed
+        templateGeneratorConfig = templateGeneratorConfig.concat(
+            (monitorInfraConstants.IS_NODE_MANAGER_INSTALLED)?
+                    [
+                         {
+                             key: 'processes',
+                             label: 'Processes',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'configProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['APISERVER'],
+                             label: 'API Server',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'configProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['SCHEMA'],
+                             label: 'Schema Transformer',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'configProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['SERVICE_MONITOR'],
+                             label: 'Service Monitor',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'configProcessStatusList.' +
+                                 monitorInfraConstants.
+                                     UVEModuleIds['DISCOVERY_SERVICE'],
+                             label: 'Discovery',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'configProcessStatusList.' +
+                                 monitorInfraConstants.UVEModuleIds['IFMAP'],
+                             label: 'Ifmap',
+                             templateGenerator: 'TextGenerator'
+                         }
+                    ]
+                    : []
+        );
+
+        templateGeneratorConfig = templateGeneratorConfig.concat(
+                [
+                    {
+                        key: 'analyticsDetails',
+                        label: 'Analytics Node',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'cpu',
+                        label: 'CPU',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'memory',
+                        label: 'Memory',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'lastLogTimestamp',
+                        label: 'Last Log',
+                        templateGenerator: 'TextGenerator'
+                    }
+                ]
+        );
+        return templateGeneratorConfig;
+    }
+
+    function getIpAddresses (confNodeData) {
+        var ips = '';
+           try{
+               iplist = getValueByJsonPath(confNodeData,
+                       "configNode;ModuleCpuState;config_node_ip",[]);
+               if(iplist instanceof Array){
+                   nodeIp = iplist[0];//using the first ip in the list for status
+               } else {
+                   nodeIp = iplist;
+               }
+           } catch(e){return noDataStr;}
+           if(iplist != null && iplist != noDataStr && iplist.length>0){
+               for (var i=0; i< iplist.length;i++){
+                   if(i+1 == iplist.length) {
+                       ips = ips + iplist[i];
+                   } else {
+                       ips = ips + iplist[i] + ', ';
+                   }
+               }
+           } else {
+              ips = noDataStr;
+           }
+           return ips;
+    }
+
+    function getAnalyticsNodeDetails (confNodeData) {
+        var anlNode = noDataStr;
+        var secondaryAnlNode, status;
+        try{
+           var contrailApiDetails = jsonPath(confNodeData,
+                                   "$..Config:contrail-api:0")[0];
+
+           anlNode = jsonPath(contrailApiDetails,
+                   "$..ModuleClientState..primary")[0].split(':')[0];
+           status = jsonPath(contrailApiDetails,
+                   "$..ModuleClientState..status")[0];
+           secondaryAnlNode = ifNull(jsonPath(contrailApiDetails,
+                   "$..ModuleClientState..secondary")[0],"").split(':')[0];
+        }catch(e){
+           anlNode = "--";
+        }
+        try{
+           if(anlNode != null && anlNode != noDataStr &&
+                   status.toLowerCase() == "established")
+              anlNode = anlNode.concat(' (Up)');
+        }catch(e){
+           if(anlNode != null && anlNode != noDataStr) {
+              anlNode = anlNode.concat(' (Down)');
+           }
+        }
+        if(secondaryAnlNode != null && secondaryAnlNode != ""
+            && secondaryAnlNode != "0.0.0.0"){
+           anlNode = anlNode.concat(', ' + secondaryAnlNode);
+        }
+        return ifNull(anlNode,noDataStr);
+    }
+
+    function getLastLogTime(aNodeData) {
+        var lmsg;
+        lmsg = getLastLogTimestamp(aNodeData,"config");
+        if(lmsg != null){
+            try{
+                return new Date(parseInt(lmsg)/1000).toLocaleString();
+            }catch(e){return noDataStr;}
+        } else return noDataStr;
+    }
+
+    function getStatusesForAllConfigProcesses(processStateList){
+        var ret = [];
+        if(processStateList != null){
+           for(var i=0; i < processStateList.length; i++){
+              var currProc = processStateList[i];
+              if(currProc.process_name == "contrail-discovery:0"){
+                 ret[monitorInfraConstants.UVEModuleIds['DISCOVERY_SERVICE']] =
+                     getProcessUpTime(currProc);
+              } else if(currProc.process_name == "contrail-discovery"){
+                 ret[monitorInfraConstants.UVEModuleIds['DISCOVERY_SERVICE']] =
+                     getProcessUpTime(currProc);
+              } else if (currProc.process_name == "contrail-api:0"){
+                 ret[monitorInfraConstants.UVEModuleIds['APISERVER']] =
+                     getProcessUpTime(currProc);
+              } else if (currProc.process_name == "contrail-api"){
+                 ret[monitorInfraConstants.UVEModuleIds['APISERVER']] =
+                     getProcessUpTime(currProc);
+              } else if (currProc.process_name == "contrail-config-nodemgr"){
+                 ret['contrail-config-nodemgr'] = getProcessUpTime(currProc);
+              } else if (currProc.process_name == "contrail-svc-monitor"){
+                 ret[monitorInfraConstants.UVEModuleIds['SERVICE_MONITOR']] =
+                                             getProcessUpTime(currProc);
+              } else if (currProc.process_name == "ifmap"){
+                 ret[monitorInfraConstants.UVEModuleIds['IFMAP']] =
+                                             getProcessUpTime(currProc);
+              } else if (currProc.process_name == "contrail-schema"){
+                 ret[monitorInfraConstants.UVEModuleIds['SCHEMA']] =
+                                             getProcessUpTime(currProc);
+              } else if (currProc.process_name == 'contrail-zookeeper') {
+                     ret['contrail-zookeeper'] = getProcessUpTime(currProc);
+                 }
+           }
+        }
+        return ret;
+    }
+
+    return ConfigNodesDetailPageView;
+});

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeDetailsView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeDetailsView.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ConfigDetailsView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            var currentHashParams = layoutHandler.getURLHashParams(),
+                tabConfig = getConfigTabsViewConfig (currentHashParams);
+
+            this.renderView4Config(this.$el, null, tabConfig, null, null, null);
+        }
+    });
+
+    function getConfigTabsViewConfig(currHashParams) {
+        var options = {
+                hostname: currHashParams.focusedElement.node
+            };
+        return {
+            elementId: cowu.formatElementId([ctwl.CONFIGNODE_TAB_SECTION_ID]),
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.CONFIGNODE_TAB_VIEW_ID,
+                                view: "ConfigNodeTabView",
+                                viewPathPrefix:
+                                    ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+                                app: cowc.APP_CONTRAIL_CONTROLLER,
+                                viewConfig: options
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+    };
+
+    return ConfigDetailsView;
+
+});

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeListView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeListView.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view','monitor-infra-confignode-model' ],
+        function(
+                _, ContrailView, ConfigNodeListModel) {
+            var ConfigNodeListView = ContrailView.extend({
+                render : function() {
+                    var configNodeListModel = new ConfigNodeListModel();
+
+                    this.renderView4Config(this.$el, configNodeListModel,
+                            getConfigNodeListViewConfig());
+                }
+            });
+
+
+            function getConfigNodeListViewConfig() {
+                var viewConfig = {
+                    rows : [
+                         {
+                            columns : [ {
+                                elementId :
+                                    ctwl.CONFIGNODE_SUMMARY_CHART_ID,
+                                title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                view : "ConfigNodeScatterChartView",
+                                viewPathPrefix:
+                                    ctwl.MONITOR_INFRA_VIEW_PATH,
+                                app : cowc.APP_CONTRAIL_CONTROLLER,
+                                    } ]
+                        },{
+                            columns : [ {
+                                elementId :
+                                    ctwl.CONFIGNODE_SUMMARY_GRID_ID,
+                                title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                view : "ConfigNodeSummaryGridView",
+                                viewPathPrefix:
+                                    ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+                                app : cowc.APP_CONTRAIL_CONTROLLER,
+                                viewConfig : {
+
+                                }
+                            } ]
+                        } ]
+                };
+                return {
+                    elementId : cowu.formatElementId(
+                        [ctwl.CONFIGNODE_SUMMARY_LIST_SECTION_ID ]),
+                    view : "SectionView",
+                    viewConfig : viewConfig
+                };
+            }
+            return ConfigNodeListView;
+        });

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeSummaryGridView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeSummaryGridView.js
@@ -1,0 +1,195 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view' ],
+        function(
+                _, ContrailView) {
+            var ConfigNodeGridView = ContrailView
+                    .extend({
+                        render : function() {
+                            var self = this,
+                                viewConfig = this.attributes.viewConfig,
+                                pagerOptions = viewConfig['pagerOptions'];
+                            this.renderView4Config(self.$el,
+                            self.model,
+                            getConfigNodeSummaryGridViewConfig(pagerOptions));
+                        }
+                    });
+
+            function getConfigNodeSummaryGridViewConfig(
+                    pagerOptions) {
+                return {
+                    elementId : ctwl.CONFIGNODE_SUMMARY_GRID_SECTION_ID,
+                    view : "SectionView",
+                    viewConfig : {
+                        rows : [ {
+                            columns : [ {
+                                elementId : ctwl.CONFIGNODE_SUMMARY_GRID_ID,
+                                title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                view : "GridView",
+                                viewConfig : {
+                                    elementConfig :
+                                        getConfigNodeSummaryGridConfig(
+                                                pagerOptions)
+                                }
+                            } ]
+                        } ]
+                    }
+                };
+            }
+
+            function getConfigNodeSummaryGridConfig(
+                    pagerOptions) {
+                var columns = [
+                   {
+                       field:"name",
+                       name:"Host name",
+                       formatter:function(r,c,v,cd,dc) {
+                          return cellTemplateLinks({
+                                          cellText:'name',
+                                          name:'name',
+                                          statusBubble:true,
+                                          rowData:dc
+                                   });
+                       },
+                       events: {
+                          onClick: onClickHostName
+                       },
+                       cssClass: 'cell-hyperlink-blue',
+                       searchFn:function(d) {
+                           return d['name'];
+                       },
+                       minWidth:90,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.name;
+                           }
+                       },
+                   },
+                   {
+                       field:"ip",
+                       name:"IP Address",
+                       minWidth:90,
+                       formatter:function(r,c,v,cd,dc){
+                           return summaryIpDisplay(dc['ip'],
+                                           dc['summaryIps']);
+                       },
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.ip;
+                           }
+                       },
+                       sorter : comparatorIP
+                   },
+                   {
+                       field:"version",
+                       name:"Version",
+                       minWidth:90
+                   },
+                   {
+                       field:"status",
+                       name:"Status",
+                       formatter:function(r,c,v,cd,dc) {
+                           return getNodeStatusContentForSummayPages(dc,'html');
+                       },
+                       searchFn:function(dc) {
+                           return getNodeStatusContentForSummayPages(dc,'text');
+                       },
+                       minWidth:110,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return
+                                   getNodeStatusContentForSummayPages(dc,'text');
+                           }
+                       }
+                   },
+                   {
+                       field:"cpu",
+                       name:"CPU (%)",
+                       formatter:function(r,c,v,cd,dc) {
+                           return '<div class="gridSparkline display-inline">' +
+                                   '</div>' +
+                                  '<span class="display-inline">' +
+                                    dc['cpu'] + '</span>';
+                       },
+                       asyncPostRender: renderSparkLines,
+                       searchFn:function(d){
+                           return d['cpu'];
+                       },
+                       minWidth:110,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.cpu;
+                           }
+                       }
+                   },
+                   {
+                       field:"memory",
+                       name:"Memory",
+                       minWidth:150,
+                       sortField:"y"
+                   }
+                ];
+                var gridElementConfig = {
+                    header : {
+                        title : {
+                            text : ctwl.CONFIGNODE_SUMMARY_TITLE
+                        }
+                    },
+                    columnHeader : {
+                        columns : columns
+                    },
+                    body : {
+                        options : {
+                          detail : false,
+                          checkboxSelectable : false
+                        },
+                        dataSource : {
+                            remote : {
+                                ajaxConfig : {
+                                    url : ctwl.CONFIGNODE_SUMMARY
+                                }
+                            },
+                            cacheConfig : {
+                                ucid: ctwl.CACHE_CONFIGNODE
+                            }
+                        }
+                    }
+                };
+                return gridElementConfig;
+            }
+
+            function onClickHostName(e, selRowDataItem) {
+                var name = selRowDataItem.name, hashParams = null,
+                    triggerHashChange = true, hostName;
+
+                hostName = selRowDataItem['name'];
+                var hashObj = {
+                        type: "configNode",
+                        view: "details",
+                        focusedElement: {
+                            node: name,
+                            tab: 'details'
+                        }
+                    };
+
+                if(contrail.checkIfKeyExistInObject(true, hashParams,
+                            'clickedElement')) {
+                    hashObj.clickedElement = hashParams.clickedElement;
+                }
+
+                layoutHandler.setURLHashParams(hashObj, {
+                    p: "mon_infra_configmvc",
+                    merge: false,
+                    triggerHashChange: triggerHashChange});
+
+            };
+
+            return ConfigNodeGridView;
+        });

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeTabView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeTabView.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ConfigNodesTabView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            self.renderView4Config(self.$el, null, getConfigNodeTabViewConfig(viewConfig));
+        }
+    });
+
+    var getConfigNodeTabViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+
+        return {
+            elementId: ctwl.CONFIGNODE_DETAILS_SECTION_ID,
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.CONFIGNODE_TABS_ID,
+                                view: "TabsView",
+                                viewConfig: getConfigNodeTabView(viewConfig)
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    };
+    
+    function getConfigNodeTabView (viewConfig) {
+        return {
+            theme: 'default',
+            active: 0,
+            activate: function (e, ui) {
+                var selTab = $(ui.newTab.context).text();
+                if (selTab == ctwl.TITLE_PORT_DISTRIBUTION) {
+                    $('#' + ctwl.NETWORK_PORT_DIST_ID).trigger('refresh');
+                } else if (selTab == ctwl.TITLE_INSTANCES) {
+                    $('#' + ctwl.PROJECT_INSTANCE_GRID_ID).data('contrailGrid').
+                        refreshView();
+                }
+            },
+            tabs: [
+               {
+                   elementId: 'confignode_detail_id',
+                   title: 'Details',
+                   view: "ConfigNodeDetailPageView",
+                   viewPathPrefix: "monitor/infrastructure/confignode/ui/js/views/",
+                   viewConfig: viewConfig
+               }
+            ]
+        }
+    }
+    return ConfigNodesTabView;
+});

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeView.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ConfigNodeView = ContrailView.extend({
+        el: $(contentContainer),
+        renderConfigNode: function (viewConfig) {
+            this.renderView4Config(this.$el, null, getConfigNodeConfig());
+        },
+        renderConfigNodeDetails : function (viewConfig) {
+            this.renderView4Config(this.$el, null, getConfigNodeDetails());
+        }
+    });
+
+    function getConfigNodeConfig() {
+        return {
+            elementId: cowu.formatElementId([ctwc.CONFIGNODE_SUMMARY_PAGE_ID]),
+            view: "ConfigNodeListView",
+            viewPathPrefix: ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+
+    function getConfigNodeDetails() {
+        return {
+            elementId: cowu.formatElementId([ctwl.CONFIGNODE_DETAILS_PAGE_ID]),
+            view: "ConfigNodeDetailsView",
+            viewPathPrefix: ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+
+    return ConfigNodeView;
+});

--- a/webroot/monitor/infrastructure/controlnode/ui/js/controlnode.main.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/controlnode.main.js
@@ -1,0 +1,36 @@
+var controlNodesLoader = new ControlNodesLoader();
+
+function ControlNodesLoader() {
+    this.load = function (paramObject) {
+        var self = this, currMenuObj = globalObj.currMenuObj,
+            hashParams = paramObject['hashParams'],
+            rootDir = currMenuObj['resources']['resource'][0]['rootDir'],
+            pathControlNodeView = rootDir + '/js/views/ControlNodeView.js',
+            renderFn = paramObject['renderFn'];
+
+            if (self.controlNodeView == null) {
+                requirejs([pathControlNodeView], function (ControlNodeView){
+                    self.controlNodeView = new ControlNodeView();
+                    self.renderView(renderFn, hashParams);
+                });
+            } else {
+                self.renderView(renderFn, hashParams);
+            }
+    }
+    this.renderView = function (renderFn, hashParams, view) {
+        $(contentContainer).html("");
+        if(hashParams.view == "details") {
+            this.controlNodeView.renderControlNodeDetails(
+                    {hashParams: hashParams});
+        } else {
+            this.controlNodeView.renderControlNode({hashParams: hashParams});
+        }
+    };
+
+    this.updateViewByHash = function (hashObj, lastHashObj) {
+        this.load({hashParams : hashObj});
+    };
+
+    this.destroy = function () {
+    };
+}

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeDetailPageView.js
@@ -1,0 +1,325 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ControlNodesDetailPageView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this;
+            var detailsTemplate = contrail.getTemplate4Id(
+                    cowc.TMPL_2COLUMN_1ROW_2ROW_CONTENT_VIEW);
+            var viewConfig = this.attributes.viewConfig;
+            var leftContainerElement = $('#left-column-container');
+            this.$el.html(detailsTemplate);
+
+
+            self.renderView4Config($('#left-column-container'), null,
+                    getControlNodeDetailPageViewConfig(viewConfig));
+        }
+    });
+    var getControlNodeDetailPageViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+        return {
+            elementId: ctwl.CONTROLNODE_DETAIL_PAGE_ID,
+            title: ctwl.TITLE_DETAILS,
+            view: "DetailsView",
+            viewConfig: {
+                ajaxConfig: {
+                    url: contrail.format(
+                            monitorInfraConstants.
+                                monitorInfraUrls['CONTROLNODE_DETAILS'],
+                            hostname),
+                    type: 'GET'
+                },
+                templateConfig: getDetailsViewTemplateConfig(),
+                app: cowc.APP_CONTRAIL_CONTROLLER,
+                dataParser: function(result) {
+                    var ctrlNodeData = result;
+                    var obj = monitorInfraParsers.
+                        parseControlNodesDashboardData([result])[0];
+                    //Further parsing required for Details page done below
+                    var overallStatus;
+                    try{
+                        overallStatus = monitorInfraUtils.
+                            getOverallNodeStatusForDetails(obj);
+                    }catch(e){overallStatus = "<span> "+statusTemplate({
+                            sevLevel:sevLevels['ERROR'],
+                            sevLevels:sevLevels})+" Down</span>";}
+
+                    try{
+                        //Add the process status list with uptime
+                        procStateList = jsonPath(ctrlNodeData,
+                                "$..NodeStatus.process_info")[0];
+                        var controlProcessStatusList =
+                            getStatusesForAllControlProcesses(procStateList);
+                        obj['controlProcessStatusList'] =
+                                controlProcessStatusList;
+                    }catch(e){}
+
+                    obj['name'] = hostname;
+
+                    obj['overallNodeStatus'] = overallStatus;
+
+                    obj['ifMapConnectionStatus'] =
+                            getIfMapConnectionStatus(ctrlNodeData);
+
+                    obj['analyticsNodeDetails'] =
+                            getAnalyticsNodeDetails(ctrlNodeData);
+
+                    obj['analyticsMessages'] =
+                            getAnalyticsNodeMessageInfo(ctrlNodeData);
+
+                    obj['peersDetails'] =
+                            getPeersDetails(obj);
+
+                    obj['vRouterPeerDetails'] =
+                            getVRouterPeersDetails(ctrlNodeData,obj);
+
+                    obj['lastLogTimestamp'] =
+                            getLastLogTime(ctrlNodeData);
+
+                    return obj;
+                }
+            }
+        }
+    }
+
+    function getDetailsViewTemplateConfig() {
+
+        return {
+            title: 'Control Node',
+            theme: 'widget-box',
+            keyClass: 'label-blue',
+            templateGenerator: 'BlockListTemplateGenerator',
+            templateGeneratorConfig: [
+                {
+                    key: 'name',
+                    label:'Hostname',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'ip',
+                    label:'IP Address',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'version',
+                    label: 'Version',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'overallNodeStatus',
+                    label: 'Overall Node Status',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'processes',
+                    label: 'Processes',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'controlProcessStatusList.contrail-control',
+                    label: 'Control Node',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'ifMapConnectionStatus',
+                    label: 'Ifmap Connection',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'analyticsNodeDetails',
+                    label: 'Analytics Node',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'analyticsMessages',
+                    label: 'Analytics Messages',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'peersDetails',
+                    label: 'Peers',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'vRouterPeerDetails',
+                    label: ' ',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'cpu',
+                    label: 'CPU',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'memory',
+                    label: 'Memory',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'lastLogTimestamp',
+                    label: 'Last Log',
+                    templateGenerator: 'TextGenerator'
+                }
+            ]
+        };
+    };
+
+    function getStatusesForAllControlProcesses(processStateList) {
+        var ret = [];
+        if (processStateList != null) {
+            for ( var i = 0; i < processStateList.length; i++) {
+                var currProc = processStateList[i];
+                if (currProc.process_name == "contrail-control-nodemgr") {
+                    ret['contrail-control-nodemgr'] = monitorInfraUtils
+                            .getProcessUpTime(currProc);
+                } else if (currProc.process_name == "contrail-control") {
+                    ret['contrail-control'] = monitorInfraUtils
+                            .getProcessUpTime(currProc);
+                }
+            }
+        }
+        return ret;
+    }
+
+    //Derive the IFmap connection status from the parsed data
+    function getIfMapConnectionStatus(ctrlNodeData) {
+        var cnfNode = '';
+        try {
+            var url = ctrlNodeData.BgpRouterState.ifmap_info.url;
+            if (url != null && url != undefined && url != "") {
+                var pos = url.indexOf(':8443');
+                if (pos != -1)
+                    cnfNode = url.substr(0, pos);
+                pos = cnfNode.indexOf('https://');
+                if (pos != -1)
+                    cnfNode = cnfNode.slice(pos + 8);
+            }
+            var status = ctrlNodeData.BgpRouterState.
+                ifmap_info.connection_status;
+            var stateChangeAtTime = ctrlNodeData.BgpRouterState.
+                                ifmap_info.connection_status_change_at;
+            var stateChangeSince = "";
+            var statusString = "";
+            if (stateChangeAtTime != null) {
+                var stateChangeAtTime = new XDate(
+                        stateChangeAtTime / 1000);
+                var currTime = new XDate();
+                stateChangeSince = diffDates(stateChangeAtTime,
+                        currTime);
+            }
+            if (status != null && status != undefined && status != "") {
+                if (stateChangeSince != "") {
+                    if (status.toLowerCase() == "up"
+                            || status.toLowerCase() == "down") {
+                        status = status + " since";
+                    }
+                    statusString = status + " " + stateChangeSince;
+                } else {
+                    statusString = status;
+                }
+            }
+            if (statusString != "") {
+                cnfNode = cnfNode.concat(' (' + statusString + ')');
+            }
+        } catch (e) {
+        }
+        return ifNull(cnfNode, noDataStr);
+    }
+
+    //Derive the ip and status of Analytics Node this is connecting to
+    function getAnalyticsNodeDetails(ctrlNodeData) {
+        var anlNode = noDataStr;
+        var secondaryAnlNode, status;
+        try{
+           anlNode = jsonPath(ctrlNodeData,
+                   "$..ModuleClientState..primary")[0].split(':')[0];
+           status = jsonPath(ctrlNodeData,"$..ModuleClientState..status")[0];
+           secondaryAnlNode = ifNull(jsonPath(ctrlNodeData,
+                   "$..ModuleClientState..secondary")[0],"").split(':')[0];
+        }catch(e){
+           anlNode = "--";
+        }
+        try{
+           if(anlNode != null && anlNode != noDataStr &&
+                   status.toLowerCase() == "established")
+              anlNode = anlNode.concat(' (Up)');
+        }catch(e){
+           if(anlNode != null && anlNode != noDataStr) {
+              anlNode = anlNode.concat(' (Down)');
+           }
+        }
+        if(secondaryAnlNode != null && secondaryAnlNode != ""
+            && secondaryAnlNode != "0.0.0.0"){
+           anlNode = anlNode.concat(', ' + secondaryAnlNode);
+        }
+        return ifNull(anlNode,noDataStr);
+    }
+
+    function getAnalyticsNodeMessageInfo(ctrlNodeData) {
+        var msgs = monitorInfraUtils.getAnalyticsMessagesCountAndSize(
+                ctrlNodeData,
+                ['contrail-control']);
+        return msgs['count']  + ' [' + formatBytes(msgs['size']) + ']';
+    }
+
+    function getPeersDetails(parsedData) {
+        var totpeers= 0,uppeers=0;
+        totpeers= ifNull(parsedData['totalBgpPeerCnt'],0);
+        uppeers = ifNull(parsedData['upBgpPeerCnt'],0);
+        var downpeers = 0;
+        if(totpeers > 0){
+            downpeers = totpeers - uppeers;
+        }
+        if (downpeers > 0){
+            downpeers = ", <span class='text-error'>"+ downpeers +
+                " Down</span>";
+        } else {
+            downpeers = "";
+        }
+        return contrail.format('BGP Peers: {0} Total {1}',totpeers,downpeers);
+    }
+
+    function getVRouterPeersDetails(ctrlNodeData,parsedData) {
+        var totXmppPeers = 0,upXmppPeers = 0,downXmppPeers = 0,subsCnt = 0;
+        totXmppPeers = parsedData['totalXMPPPeerCnt'];
+        upXmppPeers = parsedData['upXMPPPeerCnt'];
+        subsCnt = ifNull(jsonPath(ctrlNodeData,
+                '$..BgpRouterState.ifmap_server_info.num_peer_clients')[0],
+                0);
+        if(totXmppPeers > 0){
+            downXmppPeers = totXmppPeers - upXmppPeers;
+        }
+        if (downXmppPeers > 0){
+            downXmppPeers = ", <span class='text-error'>"+ downXmppPeers
+            +" Down</span>";
+        } else {
+            downXmppPeers = "";
+        }
+        if (subsCnt > 0){
+            subsCnt = ", "+ subsCnt +" subscribed for configuration";
+        } else {
+            subsCnt = ""
+        }
+        return contrail.format('vRouters: {0} Established in Sync{1}{2} ',
+                upXmppPeers,downXmppPeers,subsCnt);
+    }
+
+    function getLastLogTime(ctrlNodeData) {
+        var lmsg;
+        lmsg = getLastLogTimestamp(ctrlNodeData,"control");
+        if(lmsg != null){
+           try{
+              return new Date(parseInt(lmsg)/1000).toLocaleString();
+           }catch(e){return noDataStr;}
+        } else return noDataStr;
+    }
+
+    return ControlNodesDetailPageView;
+});

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeDetailsView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeDetailsView.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ControlNodeDetailsView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            var currentHashParams = layoutHandler.getURLHashParams(),
+                tabConfig = {};
+
+//            if (contrail.checkIfExist(currentHashParams.clickedElement)) {
+                tabConfig = getControlNodeTabsViewConfig (currentHashParams);
+//            } else {
+//                tabConfig = ctwgrc.getTabsViewConfig(ctwc.GRAPH_ELEMENT_NETWORK, {
+//                    fqName: networkFQN,
+//                    uuid: networkUUID
+//                });
+//            }
+
+            this.renderView4Config(this.$el, null, tabConfig, null, null, null);
+        }
+    });
+
+    function getControlNodeTabsViewConfig(currHashParams) {
+        var options = {
+                hostname: currHashParams.focusedElement.node
+            };
+        return {
+            elementId: cowu.formatElementId([ctwl.CONTROLNODE_TAB_SECTION_ID]),
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.CONTROLNODE_TAB_VIEW_ID,
+                                view: "ControlNodeTabView",
+                                viewPathPrefix: ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+                                app: cowc.APP_CONTRAIL_CONTROLLER,
+                                viewConfig: options
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+    };
+
+    return ControlNodeDetailsView;
+
+});

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeListView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeListView.js
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view', 'monitor-infra-controlnode-model'],
+        function(
+                _, ContrailView, ControlNodeListModel) {
+            var ControlNodeListView = ContrailView.extend({
+                render : function() {
+                    var controlNodeListModel = new ControlNodeListModel();
+                    this.renderView4Config(this.$el, controlNodeListModel,
+                            getControlNodeListViewConfig());
+                }
+            });
+
+            function getControlNodeListViewConfig() {
+                var viewConfig = {
+                    rows : [{
+                        columns : [{
+                            elementId :
+                                ctwl.CONTROLNODE_SUMMARY_CHART_ID,
+                            title : ctwl.CONTROLNODE_SUMMARY_TITLE,
+                            view : "ControlNodeScatterChartView",
+                            viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
+                            app : cowc.APP_CONTRAIL_CONTROLLER,
+                        }]
+                    },{
+                        columns : [{
+                            elementId :
+                                ctwl.CONTROLNODE_SUMMARY_GRID_ID,
+                            title : ctwl.CONTROLNODE_SUMMARY_TITLE,
+                            view : "ControlNodeSummaryGridView",
+                            viewPathPrefix: ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+                            app : cowc.APP_CONTRAIL_CONTROLLER,
+                            viewConfig : {
+                            }
+                        }]
+                    }]
+                };
+                return {
+                    elementId : cowu.formatElementId([
+                         ctwl.CONTROLNODE_SUMMARY_LIST_SECTION_ID ]),
+                    view : "SectionView",
+                    viewConfig :viewConfig
+                };
+            };
+        return ControlNodeListView;
+    });

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodePeersGridView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodePeersGridView.js
@@ -1,0 +1,260 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view',
+    'contrail-list-model'
+], function (_, ContrailView, ContrailListModel) {
+    var hostname;
+    var ControlNodePeersGridView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this;
+            var viewConfig = this.attributes.viewConfig;
+            hostname = viewConfig['hostname'];
+            var remoteAjaxConfig = {
+                    remote: {//TODO need to verify if the pagination is actually working
+                        ajaxConfig: {
+                            url: contrail.format(
+                                    monitorInfraConstants.
+                                    monitorInfraUrls['CONTROLNODE_PEERS'],
+                                    hostname, 40),
+                            type: "GET",
+                        },
+                        dataParser: processPeerInfo
+                    },
+                    cacheConfig: {
+                        ucid: "controlnode_peers_list"
+                    }
+            }
+            var contrailListModel = new ContrailListModel(remoteAjaxConfig);
+
+            self.renderView4Config(this.$el, contrailListModel,
+                    getControlNodePeersViewConfig(viewConfig));
+        }
+    });
+
+    var getControlNodePeersViewConfig = function (viewConfig) {
+        return {
+            elementId : ctwl.CONTROLNODE_PEERS_GRID_SECTION_ID,
+            view : "SectionView",
+            viewConfig : {
+                rows : [ {
+                    columns : [ {
+                        elementId : ctwl.CONTROLNODE_PEERS_GRID_ID,
+                        title : ctwl.CONTROLNODE_PEERS_TITLE,
+                        view : "GridView",
+                        viewConfig : {
+                            elementConfig :
+                                getControlNodePeersGridConfig()
+                        }
+                    } ]
+                } ]
+            }
+        }
+    }
+
+
+    function getControlNodePeersGridConfig() {
+
+    var columns = [ {
+        field : "peer_address",
+        id : "peer_address",
+        name : "Peer",
+        width : 150,
+        cssClass : 'cell-hyperlink-blue',
+        events : {
+            onClick : function(e, dc) {
+                showObjLog(dc.name, dc.encoding + '_peer');
+            }
+        },
+        sortable : true,
+        sorter : comparatorIP
+    }, {
+        field : "encoding",
+        id : "encoding",
+        name : "Peer Type",
+        width : 125,
+        sortable : true
+    }, {
+        field : "peer_asn",
+        id : "peer_asn",
+        name : "Peer ASN",
+        width : 125,
+        sortable : true
+    }, {
+        field : "introspect_state",
+        id : "introspect_state",
+        name : "Status",
+        width : 250,
+        sortable : true
+    }, {
+        field : "last_flap",
+        id : "last_flap",
+        name : "Last flap",
+        width : 200,
+        sortable : true
+    }, {
+        field : 'messsages_in',
+        id : 'messsages_in',
+        width : 160,
+        name : "Messages (Recv/Sent)",
+        formatter : function(r, c, v, cd, dc) {
+            return dc.messsages_in + ' / ' + dc.messsages_out;
+        },
+        sortable : true
+    } ];
+    var gridElementConfig = {
+        header : {
+            title : {
+                text : ctwl.CONTROLNODE_PEERS_TITLE
+            }
+        },
+        columnHeader : {
+            columns : columns
+        },
+        body : {
+            options : {
+                detail : false,
+                checkboxSelectable : false
+            },
+            dataSource : {
+                data : []
+            // remote : {
+            // ajaxConfig : {
+            // url : ctwl.CONTROLNODE_SUMMARY
+            //                        }
+            //                    },
+            //                    cacheConfig : {
+            //                    // ucid: smwc.UCID_ALL_CLUSTER_LIST
+            //                    }
+            }
+        }
+    };
+    return gridElementConfig;
+
+}
+
+    this.processPeerInfo = function(peerInfo)
+    {
+        if(peerInfo != null && peerInfo.data != null) {
+            peerInfo = peerInfo.data;
+        } else {
+            return [];
+        }
+        var ret = [];
+        //first process the bgp peers
+        var bgpPeerInfo = getValueByJsonPath(peerInfo,'bgp-peer;value',[]);
+        ret = self.processPeerDetails(bgpPeerInfo,'bgp',ret,hostname);
+        //now process xmpp peers
+        var xmppPeerInfo = getValueByJsonPath(peerInfo,'xmpp-peer;value',[]);
+        ret = self.processPeerDetails(xmppPeerInfo,'xmpp',ret,hostname);
+        return ret;
+    }
+
+    this.processPeerDetails = function(bgpPeerInfo,type,ret,hostname){
+      for(var i = 0; i < bgpPeerInfo.length; i++) {
+         var obj = {};
+         obj['raw_json'] = bgpPeerInfo[i];
+         var peerInfodata ;
+         if(type == 'bgp'){
+            try {
+                  var nameArr = bgpPeerInfo[i]['name'].split(':');
+                  if ((hostname == nameArr[4])) {
+                      obj['encoding'] = 'BGP';
+                      obj['peer_address'] = ifNull(
+                              bgpPeerInfo[i].value.BgpPeerInfoData.peer_address,
+                              noDataStr);
+                  } else {
+                     continue;//skip if it is not for this control node
+                  }
+                  peerInfodata = bgpPeerInfo[i].value.BgpPeerInfoData;
+              } catch(e) {
+               obj['peer_address'] = '-';
+              }
+         } else if (type == 'xmpp') {
+            try{
+                    var nameArr = bgpPeerInfo[i]['name'].split(':');
+                    obj['peer_address'] = nameArr[1];
+                    obj['encoding'] = 'XMPP';
+                    peerInfodata = bgpPeerInfo[i].value.XmppPeerInfoData;
+            } catch(e){}
+         }
+         try{
+            obj['name'] = ifNull(jsonPath(bgpPeerInfo[i],'$..name')[0],
+                            noDataStr);
+         }catch(e){
+            obj['name'] = "-"
+         }
+         try{
+            obj['send_state'] = ifNull(jsonPath(peerInfodata,'$..send_state'),
+                                    noDataStr);
+            if(obj['send_state'] == false)
+                  obj['send_state'] = '-';
+         }catch(e){
+            obj['send_state'] = '-';
+         }
+         try{
+            obj['peer_asn'] = ifNull(jsonPath(peerInfodata,'$..peer_asn')[0],
+                                noDataStr);
+            if(obj['peer_asn'] == null)
+                  obj['peer_asn'] = '-';
+         }catch(e){
+            obj['peer_asn'] = '-';
+         }
+         try{
+            obj = self.copyObject(obj, peerInfodata['state_info']);
+         }catch(e){}
+         try{
+            obj = self.copyObject(obj, peerInfodata['event_info']);
+         }catch(e){
+            obj['routing_tables'] = '-';
+         }
+         try{
+               obj['routing_tables'] = peerInfodata['routing_tables'];
+         }catch(e){}
+            try {
+                obj['last_flap'] = new XDate(
+                        peerInfodata['flap_info']['flap_time']/1000).
+                        toLocaleString();
+            } catch(e) {
+                obj['last_flap'] = '-';
+            }
+            obj['messsages_in'] = getValueByJsonPath(
+                                    peerInfodata,
+                                    'peer_stats_info;rx_proto_stats;total',
+                                    noDataStr);
+            obj['messsages_out'] = getValueByJsonPath(
+                                    peerInfodata,
+                                    'peer_stats_info;tx_proto_stats;total',
+                                    noDataStr);
+            try {
+                var state = obj['state'];
+                var introspecState = null;
+                if (null == state) {
+                    introspecState = '' + obj['send_state'];
+                } else {
+                    introspecState = state + ', ' + obj['send_state'];
+                }
+                obj['introspect_state'] = introspecState;
+            } catch(e) {
+                obj['introspect_state'] = '-';
+            }
+            ret.push(obj);
+      }//for loop for bgp peers END
+      return ret;
+    }
+
+    this.copyObject = function(dest, src)
+    {
+        for (key in src) {
+            dest[key] = src[key];
+        }
+        return dest;
+    }
+
+    return ControlNodePeersGridView;
+});

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeSummaryGridView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeSummaryGridView.js
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view' ],
+        function(
+                _, ContrailView) {
+            var ControlNodeSummartGridView = ContrailView
+                    .extend({
+                        render : function() {
+                            var self = this,
+                                viewConfig = this.attributes.viewConfig,
+                                pagerOptions = viewConfig['pagerOptions'];
+                            this.renderView4Config(self.$el,
+                            self.model,
+                            getControlNodeSummaryGridViewConfig(pagerOptions));
+                        }
+                    });
+
+            function getControlNodeSummaryGridViewConfig(
+                    pagerOptions) {
+                return {
+                    elementId : ctwl.CONTROLNODE_SUMMARY_GRID_SECTION_ID,
+                    view : "SectionView",
+                    viewConfig : {
+                        rows : [ {
+                            columns : [ {
+                                elementId : ctwl.CONTROLNODE_SUMMARY_GRID_ID,
+                                title : ctwl.CONTROLNODE_SUMMARY_TITLE,
+                                view : "GridView",
+                                viewConfig : {
+                                    elementConfig :
+                                        getControlNodeSummaryGridConfig(
+                                                pagerOptions)
+                                }
+                            } ]
+                        } ]
+                    }
+                };
+            }
+
+            function getControlNodeSummaryGridConfig(
+                    pagerOptions) {
+                var columns = [
+                   {
+                       field:"name",
+                       name:"Host name",
+                       formatter:function(r,c,v,cd,dc) {
+                          return cellTemplateLinks({cellText:'name',
+                              name:'name',
+                              statusBubble:true,
+                              rowData:dc});
+                       },
+                       events: {
+                          onClick: onClickHostName
+                       },
+                       cssClass: 'cell-hyperlink-blue',
+                       minWidth:110,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.name;
+                           }
+                       }
+                   },
+                   {
+                       field:"ip",
+                       name:"IP Address",
+                       formatter:function(r,c,v,cd,dc){
+                           return summaryIpDisplay(dc['ip'],dc['summaryIps']);
+                       },
+                       minWidth:90,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.ip;
+                           }
+                       },
+                       sorter : comparatorIP
+                   },
+                   {
+                       field:"version",
+                       name:"Version",
+                       minWidth:150
+                   },
+                   {
+                       field:"status",
+                       name:"Status",
+                       sortable:true,
+                       formatter:function(r,c,v,cd,dc) {
+                           return getNodeStatusContentForSummayPages(dc,'html');
+                       },
+                       searchFn:function(d) {
+                           return getNodeStatusContentForSummayPages(d,'text');
+                       },
+                       minWidth:150
+                   },
+                   {
+                       field:"cpu",
+                       name:"CPU (%)",
+                       formatter:function(r,c,v,cd,dc) {
+                           return '<div class="gridSparkline display-inline">'+
+                               '</div><span class="display-inline">'
+                               + dc['cpu'] + '</span>';
+                       },
+                       asyncPostRender: renderSparkLines,
+                       searchFn:function(d){
+                           return d['cpu'];
+                       },
+                       minWidth:150,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc['cpu'];
+                           }
+                       }
+                   },
+                   {
+                       field:"memory",
+                       name:"Memory",
+                       minWidth:110,
+                       sortField:"y"
+                   },
+                   {
+                       field:"establishedPeerCount",
+                       name:"BGP Peers",
+                       minWidth:140,
+                       formatter:function(r,c,v,cd,dc){
+                           return contrail.format("{0} Total {1}",
+                               ifNull(dc['totalBgpPeerCnt'],0),
+                               dc['downBgpPeerCntText']);
+                       }
+                   },
+                   {
+                       field:"activevRouterCount",
+                       name:"vRouters",
+                       formatter:function(r,c,v,cd,dc){
+                           return contrail.format("{0} Total {1}",
+                               dc['totalXMPPPeerCnt'],
+                               dc['downXMPPPeerCntText']);
+                       },
+                       minWidth:140
+                   }
+                ];
+                var gridElementConfig = {
+                    header : {
+                        title : {
+                            text : ctwl.CONTROLNODE_SUMMARY_TITLE
+                        }
+                    },
+                    columnHeader : {
+                        columns : columns
+                    },
+                    body : {
+                        options : {
+                          detail : false,
+                          checkboxSelectable : false
+                        },
+                        dataSource : {
+                            remote : {
+                                ajaxConfig : {
+                                    url : ctwl.CONTROLNODE_SUMMARY
+                                }
+                            },
+                            cacheConfig : {
+                                ucid: ctwl.CACHE_CONTROLNODE
+                            }
+                        }
+                    }
+                };
+                return gridElementConfig;
+            }
+
+            function onClickHostName(e, selRowDataItem) {
+                var name = selRowDataItem.name, hashParams = null,
+                    triggerHashChange = true, hostName;
+
+                hostName = selRowDataItem['name'];
+                var hashObj = {
+                        type: "controlNode",
+                        view: "details",
+                        focusedElement: {
+                            node: name,
+                            tab: 'details'
+                        }
+                    };
+
+                if(contrail.checkIfKeyExistInObject(true,
+                                hashParams,
+                                'clickedElement')) {
+                    hashObj.clickedElement = hashParams.clickedElement;
+                }
+
+                layoutHandler.setURLHashParams(hashObj, {
+                    p: "mon_infra_controlmvc",
+                    merge: false,
+                    triggerHashChange: triggerHashChange});
+
+            };
+
+            return ControlNodeSummartGridView;
+        });

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeTabView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeTabView.js
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ControlNodesTabView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            self.renderView4Config(self.$el, null, getControlNodeTabsViewConfig(viewConfig));
+        }
+    });
+
+    var getControlNodeTabsViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+
+        return {
+            elementId: ctwl.CONTROLNDOE_DETAILS_SECTION_ID,
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.CONTROLNODE_DETAILS_TABS_ID,
+                                view: "TabsView",
+                                viewConfig: getControlNodeTabViewConfig(
+                                                viewConfig)
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    };
+
+    function getControlNodeTabViewConfig (viewConfig) {
+        return {
+            theme: 'default',
+            active: 0,
+            activate: function (e, ui) {
+                var selTab = $(ui.newTab.context).text();
+                if (selTab ==
+                        ctwl.TITLE_PORT_DISTRIBUTION) {
+                    $('#' + ctwl.NETWORK_PORT_DIST_ID).
+                        trigger('refresh');
+                } else if (selTab == 'Peers') {
+    //                $('#' + ctwl.CONTROLNODE_PEERS_GRID_ID).
+//                    data('contrailGrid').refreshView();
+                }
+            },
+            tabs: [
+                   {
+                       elementId: 'controlnode_detail_id',
+                       title: 'Details',
+                       view: "ControlNodeDetailPageView",
+                       viewPathPrefix:
+                           ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+                       viewConfig: viewConfig
+                   },
+                   {
+                       elementId:
+                           ctwl.CONTROLNODE_PEERS_GRID_VIEW_ID,
+                       title: 'Peers',
+                       view: "ControlNodePeersGridView",
+                       viewPathPrefix:
+                           ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+                       viewConfig: viewConfig
+                   }
+
+                /*{
+                    elementId: 'controlnode_routes_id',
+                    title: 'Routes',
+                    view: "DetailsView",
+                    viewConfig: {
+                        ajaxConfig: {
+                            url:
+                        },
+                        templateConfig: getDetailsViewTemplateConfig(),
+                        app: cowc.APP_CONTRAIL_CONTROLLER,
+                        dataParser: function(result) {
+                            return monitorInfraParsers.
+                            parseControlNodesDashboardData([result])[0];
+                        }
+                    }
+                },
+                {
+                    elementId: 'controlnode_console_id',
+                    title: 'Console',
+                    view: "DetailsView",
+                    viewConfig: {
+                        ajaxConfig: {
+                            url: '',
+                            type: 'GET'
+                        },
+                        templateConfig: getDetailsViewTemplateConfig(),
+                        app: cowc.APP_CONTRAIL_CONTROLLER,
+                        dataParser: function(result) {
+                            return monitorInfraParsers.
+                            parseControlNodesDashboardData([result])[0];
+                        }
+                    }
+                }*/
+            ]
+        }
+    }
+    return ControlNodesTabView;
+});

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeView.js
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var ControlNodeView = ContrailView.extend({
+        el: $(contentContainer),
+        renderControlNode: function (viewConfig) {
+            this.renderView4Config(this.$el, null, getControlNodeListConfig());
+        },
+        renderControlNodeDetails : function (viewConfig) {
+            this.renderView4Config(this.$el, null, getControlNodeDetails());
+        }
+    });
+
+    function getControlNodeListConfig() {
+        return {
+            elementId: cowu.formatElementId([ctwl.CONTROLNODE_SUMMARY_PAGE_ID]),
+            view: "ControlNodeListView",
+            viewPathPrefix: ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+
+    function getControlNodeDetails() {
+        return {
+            elementId: cowu.formatElementId([ctwl.CONTROLNODE_DETAILS_PAGE_ID]),
+            view: "ControlNodeDetailsView",
+            viewPathPrefix: ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+    return ControlNodeView;
+});

--- a/webroot/monitor/infrastructure/databasenode/ui/js/databasenode.main.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/databasenode.main.js
@@ -1,0 +1,36 @@
+var databaseNodesLoader = new DatabaseNodesLoader();
+
+function DatabaseNodesLoader() {
+    this.load = function (paramObject) {
+        var self = this, currMenuObj = globalObj.currMenuObj,
+            hashParams = paramObject['hashParams'],
+            rootDir = currMenuObj['resources']['resource'][0]['rootDir'],
+            pathDatabaseView = rootDir + '/js/views/DatabaseNodeView.js',
+            renderFn = paramObject['renderFn'];
+
+            if (self.databaseNodeView == null) {
+                requirejs([pathDatabaseView], function (DatabaseNodeListView) {
+                    self.databaseNodeView = new DatabaseNodeListView();
+                    self.renderView(renderFn, hashParams);
+                });
+            } else {
+                self.renderView(renderFn, hashParams);
+            }
+    };
+    this.renderView = function (renderFn, hashParams) {
+        $(contentContainer).html("");
+        if(hashParams.view == "details") {
+            this.databaseNodeView.renderDatabaseNodeDetails({
+                hashParams: hashParams});
+        } else {
+            this.databaseNodeView.renderDatabaseNode({hashParams: hashParams});
+        }
+    };
+
+    this.updateViewByHash = function (hashObj, lastHashObj) {
+        this.load({hashParams : hashObj});
+    };
+
+    this.destroy = function () {
+    };
+}

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeDetailPageView.js
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view',
+], function (_, ContrailView) {
+    var DatabaseNodesDetailPageView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this;
+            var detailsTemplate = contrail.getTemplate4Id(
+                    cowc.TMPL_2COLUMN_1ROW_2ROW_CONTENT_VIEW);
+            var viewConfig = this.attributes.viewConfig;
+            var leftContainerElement = $('#left-column-container');
+            this.$el.html(detailsTemplate);
+
+            self.renderView4Config($('#left-column-container'), null,
+                    getDatabaseNodeDetailPageViewConfig(viewConfig));
+        }
+    });
+    var getDatabaseNodeDetailPageViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+        return {
+            elementId: ctwl.DATABASENODE_DETAIL_PAGE_ID,
+            title: ctwl.TITLE_DETAILS,
+            view: "DetailsView",
+            viewConfig: {
+                ajaxConfig: {
+                    url: contrail.format(
+                            monitorInfraConstants.
+                            monitorInfraUrls['DATABASE_DETAILS'], hostname),
+                    type: 'GET'
+                },
+                templateConfig: getDetailsViewTemplateConfig(),
+                app: cowc.APP_CONTRAIL_CONTROLLER,
+                dataParser: function(result) {
+                    var databaseNodeData = result;
+                    var obj = monitorInfraParsers.
+                        parseDatabaseNodesDashboardData([
+                                         {name:hostname,value:result}])[0];
+                    //Further parsing required for Details page done below
+
+                    var overallStatus;
+                    try{
+                        overallStatus = monitorInfraUtils.
+                            getOverallNodeStatusForDetails(obj);
+                    }catch(e){overallStatus = "<span> "+
+                        statusTemplate({sevLevel:sevLevels['ERROR'],
+                            sevLevels:sevLevels})+" Down</span>";
+                    }
+
+                    try{
+                        //Add the process status list with uptime
+                        var procStateList = jsonPath(databaseNodeData,
+                                "$..NodeStatus.process_info")[0];
+                        obj['databaseProcessStatusList'] =
+                            getStatusesForAllDbProcesses(procStateList);
+                    }catch(e){}
+
+                    obj['name'] = hostname;
+
+                    obj['overAllStatus'] = overallStatus;
+
+                    return obj;
+                }
+            }
+        }
+    }
+
+    function getDetailsViewTemplateConfig() {
+        return {
+            title: 'Database Node',
+            templateGenerator: 'BlockListTemplateGenerator',
+            theme: 'widget-box',
+            keyClass: 'label-blue',
+            templateGeneratorConfig: getTemplateGeneratorConfig()
+        };
+    };
+
+    function getTemplateGeneratorConfig() {
+        var templateGeneratorConfig = [];
+        templateGeneratorConfig = templateGeneratorConfig.concat([
+                {
+                    key: 'name',
+                    label:'Hostname',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'ip',
+                    label:'IP Address',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'version',
+                    label: 'Version',
+                    templateGenerator: 'TextGenerator'
+                },
+                {
+                    key: 'overAllStatus',
+                    label: 'Overall Node Status',
+                    templateGenerator: 'TextGenerator'
+                }
+        ]);
+        //Add proccesses info only if the node manager is installed
+        templateGeneratorConfig = templateGeneratorConfig.concat(
+            (monitorInfraConstants.IS_NODE_MANAGER_INSTALLED)?
+                    [
+                         {
+                             key: 'processes',
+                             label: 'Processes',
+                             templateGenerator: 'TextGenerator'
+                         },
+                         {
+                             key: 'databaseProcessStatusList.' +
+                                 monitorInfraConstants.UVEModuleIds['DATABASE'],
+                             label: 'Database',
+                             templateGenerator: 'TextGenerator'
+                         }
+                    ]
+                    : []
+        );
+
+        templateGeneratorConfig = templateGeneratorConfig.concat(
+                [
+                    {
+                        key: 'databaseUsage',
+                        label: 'Database Usage',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'formattedAvailableSpace',
+                        label: 'Available Space',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'formattedUsedSpaceWithPercentage',
+                        label: 'Used Space',
+                        templateGenerator: 'TextGenerator'
+                    },
+                    {
+                        key: 'formattedAnalyticsDbSize',
+                        label: 'Analytics DB Size',
+                        templateGenerator: 'TextGenerator'
+                    }
+
+                ]
+        );
+        return templateGeneratorConfig;
+    }
+
+    function getStatusesForAllDbProcesses(processStateList){
+        var ret = [];
+        if(processStateList != null){
+           for(var i=0; i < processStateList.length; i++){
+              var currProc = processStateList[i];
+              if(currProc.process_name ==
+                  monitorInfraConstants.UVEModuleIds['KAFKA']){
+                  ret[monitorInfraConstants.UVEModuleIds['KAFKA']] =
+                      getProcessUpTime(currProc);
+              } else if(currProc.process_name ==
+                  monitorInfraConstants.UVEModuleIds['DATABASE']){
+                 ret[monitorInfraConstants.UVEModuleIds['DATABASE']] =
+                     getProcessUpTime(currProc);
+              }
+           }
+        }
+        return ret;
+     }
+
+    return DatabaseNodesDetailPageView;
+});

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeDetailsView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeDetailsView.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var DatabaseDetailsView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            var currentHashParams = layoutHandler.getURLHashParams(),
+                tabConfig = getDatabaseTabsViewConfig (currentHashParams);
+
+            this.renderView4Config(this.$el, null, tabConfig, null, null, null);
+        }
+    });
+
+    function getDatabaseTabsViewConfig(currHashParams) {
+        var options = {
+                hostname: currHashParams.focusedElement.node
+            };
+        return {
+            elementId: cowu.formatElementId([ctwl.DATABASENODE_TAB_SECTION_ID]),
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.DATABASENODE_TAB_VIEW_ID,
+                                view: "DatabaseNodeTabView",
+                                viewPathPrefix: ctwl.DATABASENODE_VIEWPATH_PREFIX,
+                                app: cowc.APP_CONTRAIL_CONTROLLER,
+                                viewConfig: options
+                            }
+                        ]
+                    }
+                ]
+            }
+        };
+    };
+
+    return DatabaseDetailsView;
+
+});

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeListView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeListView.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view', 'monitor-infra-databasenode-model'],
+        function(
+                _, ContrailView, DatabaseNodeListModel) {
+            var DatabaseNodeListView = ContrailView.extend({
+                render : function() {
+                    var databaseNodeListModel = new DatabaseNodeListModel();
+                    this.renderView4Config(this.$el, databaseNodeListModel,
+                            getDatabaseNodeListViewConfig());
+                }
+            });
+
+            function getDatabaseNodeListViewConfig() {
+                var viewConfig = {
+                    rows : [
+                        {
+                            columns : [{
+                                elementId :
+                                    ctwl.DATABASENODE_SUMMARY_CHART_ID,
+                                title : ctwl.DATABASENODE_SUMMARY_TITLE,
+                                app : cowc.APP_CONTRAIL_CONTROLLER,
+                                view : "DatabaseNodeScatterChartView",
+                                viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH
+                            }]
+                        },
+                        {
+                            columns : [{
+                                elementId :
+                                    ctwl.DATABASENODE_SUMMARY_GRID_ID,
+                                title : ctwl.DATABASENODE_SUMMARY_TITLE,
+                                view : "DatabaseNodeSummaryGridView",
+                                viewPathPrefix:
+                                    ctwl.DATABASENODE_VIEWPATH_PREFIX,
+                                app : cowc.APP_CONTRAIL_CONTROLLER,
+                                viewConfig : {
+
+                                }
+                            }]
+                        } ]
+                };
+                return {
+                    elementId : cowu.formatElementId([
+                        ctwl.DATABASENODE_SUMMARY_LIST_SECTION_ID ]),
+                    view : "SectionView",
+                    viewConfig : viewConfig
+                };
+            };
+            return DatabaseNodeListView;
+        });

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeSummaryGridView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeSummaryGridView.js
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define(
+        [ 'underscore', 'contrail-view' ],
+        function(
+                _, ContrailView) {
+            var DatabaseNodeGridView = ContrailView
+                    .extend({
+                        render : function() {
+                            var self = this,
+                                viewConfig = this.attributes.viewConfig,
+                                pagerOptions = viewConfig['pagerOptions'];
+                            this.renderView4Config(self.$el,
+                                 self.model,
+                                 getDatabaseNodeSummaryGridViewConfig(
+                                     pagerOptions));
+                        }
+                    });
+
+            function getDatabaseNodeSummaryGridViewConfig(
+                    pagerOptions) {
+                return {
+                    elementId : ctwl.DATABASENODE_SUMMARY_GRID_SECTION_ID,
+                    view : "SectionView",
+                    viewConfig : {
+                        rows : [ {
+                            columns : [ {
+                                elementId : ctwl.DATABASENODE_SUMMARY_GRID_ID,
+                                title : ctwl.DATABASENODE_SUMMARY_TITLE,
+                                view : "GridView",
+                                viewConfig : {
+                                    elementConfig :
+                                        getDatabaseNodeSummaryGridConfig(
+                                            pagerOptions)
+                                }
+                            } ]
+                        } ]
+                    }
+                };
+            }
+
+            function getDatabaseNodeSummaryGridConfig(
+                    pagerOptions) {
+                var columns = [
+                   {
+                       field:"name",
+                       name:"Host name",
+                       formatter:function(r,c,v,cd,dc) {
+                          return cellTemplateLinks({cellText:'name',
+                              name:'name',
+                              statusBubble:true,
+                              rowData:dc});
+                       },
+                       events: {
+                          onClick: onClickHostName
+                       },
+                       cssClass: 'cell-hyperlink-blue',
+                       searchFn:function(d) {
+                           return d['name'];
+                       },
+                       minWidth:90,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return dc.name;
+                           }
+                       },
+                   },
+                   {
+                       field:"ip",
+                       name:"IP Address",
+                       minWidth:110,
+                       sorter : comparatorIP
+                   },
+                   {
+                       field:"status",
+                       id:"status",
+                       name:"Status",
+                       sortable:true,
+                       formatter:function(r,c,v,cd,dc) {
+                           return getNodeStatusContentForSummayPages(dc,'html');
+                       },
+                       searchFn:function(d) {
+                           return getNodeStatusContentForSummayPages(d,'text');
+                       },
+                       minWidth:110,
+                       exportConfig: {
+                           allow: true,
+                           advFormatter: function(dc) {
+                               return getNodeStatusContentForSummayPages(dc,
+                                   'text');
+                           }
+                       }
+                   },
+                   {
+                       field:"formattedAvailableSpace",
+                       name:"Available Space",
+                       minWidth:110,
+                       sortField:"dbSpaceAvailable"
+                   },
+                   {
+                       field:"formattedUsedSpace",
+                       name:"Used Space",
+                       minWidth:110,
+                       sortField:"dbSpaceUsed"
+                   },
+                   {
+                       field:"formattedAnalyticsDbSize",
+                       name:"Analytics DB Size",
+                       minWidth:110,
+                       sortField:"analyticsDbSize"
+                   }
+                ];
+                var gridElementConfig = {
+                    header : {
+                        title : {
+                            text : ctwl.DATABASENODE_SUMMARY_TITLE
+                        }
+                    },
+                    columnHeader : {
+                        columns : columns
+                    },
+                    body : {
+                        options : {
+                          detail : false,
+                          checkboxSelectable : false
+                        },
+                        dataSource : {
+                            remote : {
+                                ajaxConfig : {
+                                    url : ctwl.DATABASENODE_SUMMARY
+                                }
+                            },
+                            cacheConfig : {
+                                ucid: ctwl.CACHE_DATABASENODE
+                            }
+                        }
+                    }
+                };
+                return gridElementConfig;
+            }
+
+            function onClickHostName(e, selRowDataItem) {
+                var name = selRowDataItem.name, hashParams = null,
+                    triggerHashChange = true, hostName;
+
+                hostName = selRowDataItem['name'];
+                var hashObj = {
+                        type: "databaseNode",
+                        view: "details",
+                        focusedElement: {
+                            node: name,
+                            tab: 'details'
+                        }
+                    };
+
+                if(contrail.checkIfKeyExistInObject(true,
+                        hashParams, 'clickedElement')) {
+                    hashObj.clickedElement = hashParams.clickedElement;
+                }
+
+                layoutHandler.setURLHashParams(hashObj, {
+                    p: "mon_infra_databasemvc",
+                    merge: false,
+                    triggerHashChange: triggerHashChange});
+
+            };
+
+            return DatabaseNodeGridView;
+        });

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeTabView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeTabView.js
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var DatabaseNodesTabView = ContrailView.extend({
+        el: $(contentContainer),
+
+        render: function () {
+            var self = this,
+                viewConfig = this.attributes.viewConfig;
+
+            self.renderView4Config(self.$el, null, getDatabaseNodeTabViewConfig(viewConfig));
+        }
+    });
+
+    var getDatabaseNodeTabViewConfig = function (viewConfig) {
+        var hostname = viewConfig['hostname'];
+
+        return {
+            elementId: ctwl.DATABASENODE_DETAILS_SECTION_ID,
+            view: "SectionView",
+            viewConfig: {
+                rows: [
+                    {
+                        columns: [
+                            {
+                                elementId: ctwl.DATABASENODE_TABS_ID,
+                                view: "TabsView",
+                                viewConfig: getTabViewConfig(viewConfig)
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    };
+
+    function getTabViewConfig(viewConfig){
+        return {
+            theme: 'default',
+            active: 0,
+            activate: function (e, ui) {
+                var selTab = $(ui.newTab.context).text();
+                if (selTab == ctwl.TITLE_PORT_DISTRIBUTION) {
+                    $('#' + ctwl.NETWORK_PORT_DIST_ID).trigger('refresh');
+                } else if (selTab == ctwl.TITLE_INSTANCES) {
+                    $('#' + ctwl.PROJECT_INSTANCE_GRID_ID).data('contrailGrid').
+                        refreshView();
+                }
+            },
+            tabs: [
+               {
+                   elementId: 'databasenode_detail_id',
+                   title: 'Details',
+                   view: "DatabaseNodeDetailPageView",
+                   viewPathPrefix: ctwl.DATABASENODE_VIEWPATH_PREFIX,
+                   viewConfig: viewConfig
+               }
+            ]
+        }
+    }
+    return DatabaseNodesTabView;
+});

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeView.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014 Juniper Networks, Inc. All rights reserved.
+ */
+
+define([
+    'underscore',
+    'contrail-view'
+], function (_, ContrailView) {
+    var DatabaseNodeView = ContrailView.extend({
+        el: $(contentContainer),
+        renderDatabaseNode: function (viewConfig) {
+            this.renderView4Config(this.$el, null, getDatabaseNodeConfig());
+        },
+        renderDatabaseNodeDetails : function (viewConfig) {
+            this.renderView4Config(this.$el, null, getDatabaseNodeDetails());
+        }
+    });
+
+    function getDatabaseNodeConfig() {
+        return {
+            elementId:
+                cowu.formatElementId([ctwl.DATATBASENODE_SUMMARY_PAGE_ID]),
+            view: "DatabaseNodeListView",
+            viewPathPrefix: ctwl.DATABASENODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+
+    function getDatabaseNodeDetails() {
+        return {
+            elementId: cowu.formatElementId([ctwl.DATABASENODE_DETAILS_PAGE_ID]),
+            view: "DatabaseNodeDetailsView",
+            viewPathPrefix: ctwl.DATABASENODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
+            viewConfig: {}
+        };
+    };
+
+    return DatabaseNodeView;
+});


### PR DESCRIPTION
Moved the Analytics,Control,Config,Database nodes summary pages to MVC coding style except the spark lines in the grid.

Added monitor.infra.init.js and moved the declaration of monitorInfraUtils to
it.

Initial Monitor Infra ControlNode MVC changes -
- Added the Details and Peers page to Control Node
- Moved the commonly used parsers to monitor.infra.parsers.js
- Created another constants file monitor.infra.constants.js to hold the URLs and
other constants used by monitor infra pages.

Related-Bug: #1488346 - Initial Analytics Details, Generators, ControlNode
Details, Peers conversion to MVC.

Conflicts:
	webroot/common/ui/js/controller.app.js
	webroot/common/ui/js/controller.init.js
	webroot/common/ui/js/controller.labels.js
	webroot/menu.xml
	webroot/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel.js
	webroot/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel.js
	webroot/monitor/infrastructure/common/ui/js/models/ControlNodeListModel.js
	webroot/monitor/infrastructure/common/ui/js/models/DatabaseNodeListModel.js

MVC changes - Config, Control, Analytics and DB Node details page. And Control
node peers, analytics node generators changes.
Also created monitor.init.js and common parsers for monitor infra.

Review Comments - used constants for viewpath
Gave proper ucid's

Change-Id: Ied6e3c72d28727e5754d823d56396d13e1d95161