### PR TITLE
Closes-Bug: #1518660

### DIFF
--- a/webroot/common/ui/js/controller.constants.js
+++ b/webroot/common/ui/js/controller.constants.js
@@ -225,14 +225,28 @@ define([
         this.UNDERLAY_VM_TAB_INDEXES = [5, 6, 7, 8, 9, 10];
         this.UNDERLAY_VROUTER_TAB_INDEXES = [11, 12, 13, 14, 15, 16, 17];
 
-        this.getProjectsURL = function (domain) {
-            //If the role is admin then we will display all the projects else the projects which has access
-            var url = '/api/tenants/projects/' + domain,
+        this.getProjectsURL = function (domainObj, dropdownOptions) {
+            /* Default: get projects from keystone or API Server as specified in
+             * config.global.js, getDomainProjectsFromApiServer is true, then
+             * from API Server else from keystone
+             */
+            var getProjectsFromIdentity = null;
+            var config = null;
+            if (null != dropdownOptions) {
+                getProjectsFromIdentity = dropdownOptions.getProjectsFromIdentity;
+                config = dropdownOptions.config;
+            }
+
+            var url = '/api/tenants/config/projects/' + domainObj.value,
                 role = globalObj['webServerInfo']['role'],
                 activeOrchModel = globalObj['webServerInfo']['loggedInOrchestrationMode'];
 
-            if (activeOrchModel == 'vcenter' || role.indexOf(roles['TENANT']) > -1) {
-                url = '/api/tenants/config/projects';
+            /* In case of vcenter, get the projects from API Server only */
+            if ((activeOrchModel == 'vcenter') ||
+                (((null == getProjectsFromIdentity) ||
+                (false == getProjectsFromIdentity)) &&
+                ((null == config) || (false == config)))) {
+                url = '/api/tenants/projects/' + domainObj.name;
             }
             return url;
         };

--- a/webroot/common/ui/js/controller.utils.js
+++ b/webroot/common/ui/js/controller.utils.js
@@ -198,11 +198,12 @@ define([
             return contrailListModel;
         };
 
-        this.getProjectListModelConfig = function(domain) {
+        this.getProjectListModelConfig = function(domainObj, dropdownOptions) {
             return {
                 remote: {
                     ajaxConfig: {
-                        url: ctwc.getProjectsURL(domain)
+                        url: ctwc.getProjectsURL(domainObj,
+                                                 dropdownOptions)
                     },
                     dataParser: function(response) {
                         return  $.map(response.projects, function (n, i) {
@@ -221,7 +222,8 @@ define([
                     }
                 },
                 cacheConfig : {
-                    ucid: ctwc.get(ctwc.UCID_BC_DOMAIN_ALL_PROJECTS, domain),
+                    ucid: ctwc.get(ctwc.UCID_BC_DOMAIN_ALL_PROJECTS,
+                                   domainObj.name),
                     loadOnTimeout: false,
                     cacheTimeout: cowc.PROJECT_CACHE_UPDATE_INTERVAL
                 }
@@ -261,7 +263,7 @@ define([
             var listModelConfig = {
                 remote: {
                     ajaxConfig: {
-                        url: ctwc.getProjectsURL(domain)
+                        url: ctwc.getProjectsURL({name: domain})
                     },
                     dataParser: function(response) {
                         return  $.map(response.projects, function (n, i) {

--- a/webroot/common/ui/js/controller.view.config.js
+++ b/webroot/common/ui/js/controller.view.config.js
@@ -228,8 +228,8 @@ define([
             var urlValue = (contrail.checkIfKeyExistInObject(true, hashParams, 'focusedElement.fqName') ? hashParams.focusedElement.fqName : null);
 
             return function(domainSelectedValueData) {
-                var domain = domainSelectedValueData.name,
-                    defaultDropdownOptions = {
+
+                var defaultDropdownOptions = {
                         urlValue: (urlValue !== null) ? urlValue.split(':').splice(1, 1).join(':') : null,
                         cookieKey: cowc.COOKIE_PROJECT,
                         parentSelectedValueData: domainSelectedValueData
@@ -240,7 +240,9 @@ define([
                     elementId: ctwl.PROJECTS_BREADCRUMB_DROPDOWN,
                     view: "BreadcrumbDropdownView",
                     viewConfig: {
-                        modelConfig: ctwu.getProjectListModelConfig(domain),
+                        modelConfig:
+                            ctwu.getProjectListModelConfig(domainSelectedValueData,
+                                                           dropdownOptions),
                         dropdownOptions: dropdownOptions
                     }
                 }

--- a/webroot/config/infra/quotas/ui/js/views/QuotasView.js
+++ b/webroot/config/infra/quotas/ui/js/views/QuotasView.js
@@ -17,6 +17,7 @@ define([
     function getQuotasConfig (viewConfig) {
         var hashParams = viewConfig.hashParams,
             customProjectDropdownOptions = {
+                config: true,
                 childView: {
                     init: getQuotas(viewConfig),
                 }

--- a/webroot/config/networking/fip/ui/js/views/fipCfgView.js
+++ b/webroot/config/networking/fip/ui/js/views/fipCfgView.js
@@ -16,17 +16,18 @@ define([
     function getFipCfgListConfig(viewConfig) {
         var hashParams = viewConfig.hashParams,
             customProjectDropdownOptions = {
+                config: true,
                 childView: {
                     init: getFipCfgViewConfig(viewConfig),
                 },
             },
             customDomainDropdownOptions = {
                 childView: {
-                    init: getProjectBreadcrumbDropdownViewConfig(hashParams,
+                    init: ctwvc.getProjectBreadcrumbDropdownViewConfig(hashParams,
                                                  customProjectDropdownOptions)
                 }
             };
-        return getDomainBreadcrumbDropdownViewConfig(hashParams,
+        return ctwvc.getDomainBreadcrumbDropdownViewConfig(hashParams,
                                                      customDomainDropdownOptions)
     };
 
@@ -43,56 +44,6 @@ define([
             }
         }
     };
-
-    function getDomainBreadcrumbDropdownViewConfig(hashParams,
-                                                     customDomainDropdownOptions) {
-        var urlValue = (contrail.checkIfKeyExistInObject(true,
-                         hashParams, 'focusedElement.fqName') ?
-                         hashParams.focusedElement.fqName : null),
-            defaultDropdownoptions = {
-                urlValue: (urlValue !== null) ?
-                             urlValue.split(':').splice(0,1).join(':') : null,
-                cookieKey: cowc.COOKIE_DOMAIN
-            },
-            dropdownOptions = $.extend(true, {},
-                             defaultDropdownoptions, customDomainDropdownOptions);
-
-        return {
-            elementId: ctwl.DOMAINS_BREADCRUMB_DROPDOWN,
-            view: "BreadcrumbDropdownView",
-            viewConfig: {
-                modelConfig: ctwu.getDomainListModelConfig(),
-                dropdownOptions: dropdownOptions
-            }
-        }
-    }
-
-    function getProjectBreadcrumbDropdownViewConfig(hashParams,
-                                                     customProjectDropdownOptions) {
-        var urlValue = (contrail.checkIfKeyExistInObject(true,
-                             hashParams, 'focusedElement.fqName') ?
-                             hashParams.focusedElement.fqName : null);
-
-        return function(domainSelectedValueData) {
-            var domain = domainSelectedValueData.name,
-                defaultDropdownOptions = {
-                    urlValue: (urlValue !== null) ?
-                             urlValue.split(':').splice(1, 1).join(':') : null,
-                    cookieKey: cowc.COOKIE_PROJECT
-                },
-                dropdownOptions = $.extend(true, {},
-                             defaultDropdownOptions, customProjectDropdownOptions);
-
-            return {
-                elementId: ctwl.PROJECTS_BREADCRUMB_DROPDOWN,
-                view: "BreadcrumbDropdownView",
-                viewConfig: {
-                    modelConfig: ctwu.getProjectListModelConfig(domain),
-                    dropdownOptions: dropdownOptions
-                }
-            }
-        };
-    }
 
     return fipCfgView;
 });

--- a/webroot/config/networking/ipam/ui/js/views/ipamCfgView.js
+++ b/webroot/config/networking/ipam/ui/js/views/ipamCfgView.js
@@ -17,17 +17,18 @@ define([
     function getipamCfgListConfig(viewConfig) {
         var hashParams = viewConfig.hashParams,
             customProjectDropdownOptions = {
+                config: true,
                 childView: {
                     init: getipamCfgViewConfig(viewConfig),
                 },
             },
             customDomainDropdownOptions = {
                 childView: {
-                    init: getProjectBreadcrumbDropdownViewConfig(hashParams,
+                    init: ctwvc.getProjectBreadcrumbDropdownViewConfig(hashParams,
                                                  customProjectDropdownOptions)
                 }
             };
-        return getDomainBreadcrumbDropdownViewConfig(hashParams,
+        return ctwvc.getDomainBreadcrumbDropdownViewConfig(hashParams,
                                                      customDomainDropdownOptions)
     };
 
@@ -44,56 +45,6 @@ define([
             }
         }
     };
-
-    function getDomainBreadcrumbDropdownViewConfig(hashParams,
-                                                     customDomainDropdownOptions) {
-        var urlValue = (contrail.checkIfKeyExistInObject(true,
-                         hashParams, 'focusedElement.fqName') ?
-                         hashParams.focusedElement.fqName : null),
-            defaultDropdownoptions = {
-                urlValue: (urlValue !== null) ?
-                             urlValue.split(':').splice(0,1).join(':') : null,
-                cookieKey: cowc.COOKIE_DOMAIN
-            },
-            dropdownOptions = $.extend(true, {},
-                             defaultDropdownoptions, customDomainDropdownOptions);
-
-        return {
-            elementId: ctwl.DOMAINS_BREADCRUMB_DROPDOWN,
-            view: "BreadcrumbDropdownView",
-            viewConfig: {
-                modelConfig: ctwu.getDomainListModelConfig(),
-                dropdownOptions: dropdownOptions
-            }
-        }
-    }
-
-    function getProjectBreadcrumbDropdownViewConfig(hashParams,
-                                                     customProjectDropdownOptions) {
-        var urlValue = (contrail.checkIfKeyExistInObject(true,
-                             hashParams, 'focusedElement.fqName') ?
-                             hashParams.focusedElement.fqName : null);
-
-        return function(domainSelectedValueData) {
-            var domain = domainSelectedValueData.name,
-                defaultDropdownOptions = {
-                    urlValue: (urlValue !== null) ?
-                             urlValue.split(':').splice(1, 1).join(':') : null,
-                    cookieKey: cowc.COOKIE_PROJECT
-                },
-                dropdownOptions = $.extend(true, {},
-                             defaultDropdownOptions, customProjectDropdownOptions);
-
-            return {
-                elementId: ctwl.PROJECTS_BREADCRUMB_DROPDOWN,
-                view: "BreadcrumbDropdownView",
-                viewConfig: {
-                    modelConfig: ctwu.getProjectListModelConfig(domain),
-                    dropdownOptions: dropdownOptions
-                }
-            }
-        };
-    }
 
     return ipamCfgView;
 });

--- a/webroot/config/networking/logicalrouter/ui/js/views/logicalRouterView.js
+++ b/webroot/config/networking/logicalrouter/ui/js/views/logicalRouterView.js
@@ -19,10 +19,10 @@ define([
         getLogicalRouterConfig: function (viewConfig) {
             var hashParams = viewConfig.hashParams,
                 customProjectDropdownOptions = {
+                    config: true,
                     childView: {
                         init: this.getLogicalRouter(viewConfig),
                     },
-                    allDropdownOption: ctwc.ALL_PROJECT_DROPDOWN_OPTION
                 },
                 customDomainDropdownOptions = {
                     childView: {

--- a/webroot/config/networking/policy/ui/js/views/policyView.js
+++ b/webroot/config/networking/policy/ui/js/views/policyView.js
@@ -18,6 +18,7 @@ define([
         getPoliciesConfig: function (viewConfig) {
             var hashParams = viewConfig.hashParams,
                 customProjectDropdownOptions = {
+                    config: true,
                     childView: {
                         init: this.getPolicies(viewConfig),
                     }/*,

--- a/webroot/config/networking/port/ui/js/views/portView.js
+++ b/webroot/config/networking/port/ui/js/views/portView.js
@@ -19,6 +19,7 @@ define([
         getPortConfig: function (viewConfig) {
             var hashParams = viewConfig.hashParams,
                 customProjectDropdownOptions = {
+                    config: true,
                     childView: {
                         init: this.getPort(viewConfig),
                     }

--- a/webroot/config/networking/securitygroup/ui/js/views/SecGrpView.js
+++ b/webroot/config/networking/securitygroup/ui/js/views/SecGrpView.js
@@ -17,6 +17,7 @@ define([
     function getSecGrpConfig (viewConfig) {
         var hashParams = viewConfig.hashParams,
             customProjectDropdownOptions = {
+                config: true,
                 childView: {
                     init: getSecGrp(viewConfig),
                 }

--- a/webroot/config/services/instances/ui/js/views/svcInstView.js
+++ b/webroot/config/services/instances/ui/js/views/svcInstView.js
@@ -18,6 +18,7 @@ define([
     function getSvcInstConfig (viewConfig) {
         var hashParams = viewConfig.hashParams,
             customProjectDropdownOptions = {
+                config: true,
                 childView: {
                     init: getSvcInst(viewConfig),
                 }

--- a/webroot/monitor/networking/ui/js/nm.utils.js
+++ b/webroot/monitor/networking/ui/js/nm.utils.js
@@ -75,7 +75,7 @@ define([
 
         if (fqNameLength == 2) {
             $.ajax({
-                url: cowc.getProjectsURL('default-domain'),
+                url: cowc.getProjectsURL({name: 'default-domain'}),
                 async: false
             }).done(function (response) {
                 $.each(response['projects'], function (idx, projObj) {

--- a/webroot/monitor/networking/ui/js/views/ProjectGridView.js
+++ b/webroot/monitor/networking/ui/js/views/ProjectGridView.js
@@ -15,7 +15,7 @@ define([
                 pagerOptions = viewConfig['pagerOptions'];
 
             var projectsRemoteConfig = {
-                url: ctwc.getProjectsURL(ctwc.DEFAULT_DOMAIN),
+                url: ctwc.getProjectsURL({name: ctwc.DEFAULT_DOMAIN}),
                 type: 'GET'
             };
 

--- a/webroot/monitor/networking/ui/js/views/ProjectListView.js
+++ b/webroot/monitor/networking/ui/js/views/ProjectListView.js
@@ -22,7 +22,7 @@ define([
         return {
             remote: {
                 ajaxConfig: {
-                    url: ctwc.getProjectsURL(ctwc.DEFAULT_DOMAIN),
+                        url: ctwc.getProjectsURL({name: ctwc.DEFAULT_DOMAIN}),
                         type: 'GET'
                 },
                 hlRemoteConfig: nmwgc.getProjectDetailsHLazyRemoteConfig(),


### PR DESCRIPTION
Currently we are using '/api/tenants/projects/<domain_name>’ which is a GET on
/projects in API Server.
So when we add a project in keystone, that does not come here with this URL. As
keystone and API servers does not get synced.

Now in monitoring pages, we need to show all the projects for admin user and in
Config pages, we need to get the projects accessible to the user, so added one
more flag getProjectsFromIdentity and set as true which gets the value from
keystone if config.getDomainProjectsFromApiServer is set as false in config
file.
Here we need to use /api/tenants/config/projects/<domain_uuid>

Change-Id: If8aa05cc056a9d74b850aa9d89efd9843222bf58