### PR TITLE
Related-Bug: #1580038

### DIFF
--- a/webroot/common/test/ui/unit/ct.unit.test.js
+++ b/webroot/common/test/ui/unit/ct.unit.test.js
@@ -1,10 +1,11 @@
 define([
+    'co-test-constants',
     'co-test-runner',
     'co-test-utils',
     'ct-test-messages',
     'common/test/ui/unit/ct.parsers.mock.data',
     'common/test/ui/unit/ct.parsers.unit.test.suite'
-], function (cotr, cotu, cttm, CTParsersUnitMockData, CTParsersUnitTestSuite) {
+], function (cotc, cotr, cotu, cttm, CTParsersUnitMockData, CTParsersUnitTestSuite) {
 
     var moduleId = cttm.CT_UNIT_TEST_MODULE;
 

--- a/webroot/common/ui/js/controller.app.js
+++ b/webroot/common/ui/js/controller.app.js
@@ -23,59 +23,101 @@ if (typeof ctBaseDir !== 'undefined') {
         ctBuildDir = globalObj['buildBaseDir'];
     }
 
+    var bundles = {};
+    var controllerBundles = {
+        'monitor-infra-module' : [
+            'monitor-infra-utils','monitor-infra-constants','monitor-infra-parsers'
+        ],
+        'nm-module' : [
+            // 'geometry','vectorizer','joint.layout.DirectedGraph','joint',
+            'contrail-graph-model','graph-view','core-basedir/js/handlers/GraphLayoutHandler'
+        ]
+    }
+    if(globalObj['env'] == "prod")
+        bundles = controllerBundles;
     require.config({
         baseUrl: ctBaseDir,
+        bundles: bundles,
         paths: getControllerAppPaths(ctBaseDir, ctBuildDir),
         waitSeconds: 0
     });
-
     require(['controller-init'], function () {});
+    loadFeatureBundles();
 }
 
-function getControllerAppPaths (ctBaseDir, ctBuildDir) {
+function loadFeatureBundles() {
+    require(['monitor-infra-module'],function() {
+    });
+}
+
+function getControllerAppPaths (ctBaseDir, ctBuildDir,env) {
     ctWebDir = ctBaseDir + ctBuildDir;
-    return {
-        'controller-srcdir': ctBaseDir,
-        'controller-basedir': ctWebDir,
-        'controller-constants': ctWebDir + '/common/ui/js/controller.constants',
-        'controller-grid-config': ctWebDir + '/common/ui/js/controller.grid.config',
-        'controller-graph-config': ctWebDir + '/common/ui/js/controller.graph.config',
-        'controller-labels': ctWebDir + '/common/ui/js/controller.labels',
-        'controller-utils': ctWebDir + '/common/ui/js/controller.utils',
-        'controller-messages': ctWebDir + '/common/ui/js/controller.messages',
-        'controller-parsers': ctWebDir + '/common/ui/js/controller.parsers',
-        'controller-view-config': ctWebDir + '/common/ui/js/controller.view.config',
-        'controller-init': ctWebDir + '/common/ui/js/controller.init',
+    if(env == null)
+        env = globalObj['env'];
+    if(env == "dev") {
+        return {
+            'controller-srcdir': ctBaseDir,
+            'controller-basedir': ctWebDir,
+            'controller-constants': ctWebDir + '/common/ui/js/controller.constants',
+            'controller-grid-config': ctWebDir + '/common/ui/js/controller.grid.config',
+            'controller-graph-config': ctWebDir + '/common/ui/js/controller.graph.config',
+            'controller-labels': ctWebDir + '/common/ui/js/controller.labels',
+            'controller-utils': ctWebDir + '/common/ui/js/controller.utils',
+            'controller-messages': ctWebDir + '/common/ui/js/controller.messages',
+            'controller-parsers': ctWebDir + '/common/ui/js/controller.parsers',
+            'controller-view-config': ctWebDir + '/common/ui/js/controller.view.config',
+            'controller-init': ctWebDir + '/common/ui/js/controller.init',
 
-        'monitor-infra-module': ctWebDir + '/monitor/infrastructure/common/ui/js/monitor.infra.module',
-        'nm-module': ctWebDir + '/monitor/networking/ui/js/nm.module',
-        'qe-module': ctWebDir + '/reports/qe/ui/js/qe.module',
+            'monitor-infra-module': ctWebDir + '/monitor/infrastructure/common/ui/js/monitor.infra.module',
+            'nm-module': ctWebDir + '/monitor/networking/ui/js/nm.module',
+            'qe-module': ctWebDir + '/reports/qe/ui/js/qe.module',
 
-        //TODO: Only commons controller level definations should be created in this file.
-        /**
-         * following files should be accessed like the following from where they're referenced.
-         * for eg: SearchFlowFormModel, use following in require call instead of path id:
-         * 'controller-basedir/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel'
-         */
-        'searchflow-model': ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel',
-        'traceflow-model': ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/TraceFlowTabModel',
-        'underlay-graph-model' : ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/UnderlayGraphModel',
-        'monitor-infra-confignode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel',
-        'monitor-infra-confignode-charts-model': ctWebDir + '/monitor/infrastructure/common/ui/js/models/ConfigNodeChartsModel',
-        'monitor-infra-analyticsnode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel',
-        'monitor-infra-databasenode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/DatabaseNodeListModel',
-        'monitor-infra-controlnode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/ControlNodeListModel',
-        'monitor-infra-vrouter-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/VRouterListModel',
-        'monitor-infra-utils' : ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils',
-        'confignode-chart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/ConfigNodeChartsView',
-        'controlnode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/ControlNodeScatterChartView',
-        'dbnode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/DatabaseNodeScatterChartView',
-        'analyticsnode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/AnalyticsNodeScatterChartView',
-        'vrouter-dashboard-view': ctWebDir + '/monitor/infrastructure/dashboard/ui/js/views/VRouterDashboardView',
-        'monitor-infra-parsers': ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers',
-        'monitor-infra-utils': ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils',
-        'monitor-infra-constants': ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.constants',
-        'mon-infra-controller-dashboard': ctWebDir + '/monitor/infrastructure/dashboard/ui/js/views/ControllerDashboardView'
+            //TODO: Only commons controller level definations should be created in this file.
+            /**
+            * following files should be accessed like the following from where they're referenced.
+            * for eg: SearchFlowFormModel, use following in require call instead of path id:
+            * 'controller-basedir/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel'
+            */
+            'searchflow-model': ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel',
+            'traceflow-model': ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/TraceFlowTabModel',
+            'underlay-graph-model' : ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/UnderlayGraphModel',
+            'monitor-infra-confignode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel',
+            'monitor-infra-confignode-charts-model': ctWebDir + '/monitor/infrastructure/common/ui/js/models/ConfigNodeChartsModel',
+            'monitor-infra-analyticsnode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel',
+            'monitor-infra-databasenode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/DatabaseNodeListModel',
+            'monitor-infra-controlnode-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/ControlNodeListModel',
+            'monitor-infra-vrouter-model' : ctWebDir + '/monitor/infrastructure/common/ui/js/models/VRouterListModel',
+            'monitor-infra-utils' : ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils',
+            'confignode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/ConfigNodeScatterChartView',
+            'controlnode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/ControlNodeScatterChartView',
+            'dbnode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/DatabaseNodeScatterChartView',
+            'analyticsnode-scatterchart-view': ctWebDir + '/monitor/infrastructure/common/ui/js/views/AnalyticsNodeScatterChartView',
+            'vrouter-dashboard-view': ctWebDir + '/monitor/infrastructure/dashboard/ui/js/views/VRouterDashboardView',
+            'monitor-infra-parsers': ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers',
+            'monitor-infra-utils': ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils',
+            'monitor-infra-constants': ctWebDir + '/monitor/infrastructure/common/ui/js/utils/monitor.infra.constants',
+            'mon-infra-controller-dashboard': ctWebDir + '/monitor/infrastructure/dashboard/ui/js/views/ControllerDashboardView',
+
+            'controller-init': ctWebDir + '/common/ui/js/controller.init',
+            'controller-dashboard-libs': ctWebDir + '/monitor/infrastructure/common/ui/js/monitor.infra.module'
+        }
+    } else if(env == "prod") {
+        return {
+            'controller-srcdir': ctBaseDir,
+            'controller-basedir': ctWebDir,
+
+            'monitor-infra-module': ctWebDir + '/monitor/infrastructure/common/ui/js/monitor.infra.module',
+            'nm-module': ctWebDir + '/monitor/networking/ui/js/nm.module',
+            'qe-module': ctWebDir + '/reports/qe/ui/js/qe.module',
+
+            //Need to list paths that are not part of bundles
+            'searchflow-model': ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel',
+            'traceflow-model': ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/TraceFlowTabModel',
+            'underlay-graph-model' : ctWebDir + '/monitor/infrastructure/underlay/ui/js/models/UnderlayGraphModel',
+
+            'controller-init': ctWebDir + '/common/ui/js/controller.init',
+            'controller-dashboard-libs': ctWebDir + '/monitor/infrastructure/common/ui/js/monitor.infra.module'
+        }
     }
 };
 

--- a/webroot/common/ui/js/controller.init.js
+++ b/webroot/common/ui/js/controller.init.js
@@ -22,7 +22,8 @@ define([
     ctwp = new Parsers();
     ctwvc = new ViewConfig();
 
-    var deferredObj = contentHandler.initFeatureAppDefObjMap[FEATURE_PCK_WEB_CONTROLLER];
+    //deferredObj reading from global variable 
+    var deferredObj = globalObj['initFeatureAppDefObjMap'][FEATURE_PCK_WEB_CONTROLLER];
 
     if(contrail.checkIfExist(deferredObj)) {
         deferredObj.resolve()

--- a/webroot/common/ui/js/controller.utils.js
+++ b/webroot/common/ui/js/controller.utils.js
@@ -458,6 +458,12 @@ define([
                 viewPathPrefix = './';
             }
             viewPath = viewPathPrefix + viewName;
+            var checkRequirePath = viewPath.replace(/^core-basedir\//,'').replace(/^controller-basedir\//,'');
+            var pathMapping = _.invert(require.s.contexts._.config.paths);
+            pathMapping = {
+                 'monitor/infrastructure/common/ui/js/views/VRouterScatterChartView' : 'vrouter-scatterchart-view'
+            }
+            // viewPath = ifNull(pathMapping[checkRequirePath],viewPath);
             require([viewPath], function(ElementView) {
                 elementView = new ElementView({el: parentElement, model: model, attributes: viewAttributes, rootView: rootView, onAllViewsRenderCompleteCB: onAllViewsRenderCompleteCB, onAllRenderCompleteCB: onAllRenderCompleteCB});
                 elementView.viewName = viewName;

--- a/webroot/config/dns/records/test/ui/views/dnsRecordsGridView.test.js
+++ b/webroot/config/dns/records/test/ui/views/dnsRecordsGridView.test.js
@@ -3,13 +3,14 @@
  */
 
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/dns/records/test/ui/views/dnsRecordsGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.DNS_RECORDS_GRID_VIEW_TEST_MODULE;
 

--- a/webroot/config/dns/servers/test/ui/views/dnsServersGridView.test.js
+++ b/webroot/config/dns/servers/test/ui/views/dnsServersGridView.test.js
@@ -3,13 +3,14 @@
  */
 
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/dns/servers/test/ui/views/dnsServersGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.DNS_SERVERS_GRID_VIEW_TEST_MODULE;
 

--- a/webroot/config/infra/bgp/test/ui/views/bgpGridView.test.js
+++ b/webroot/config/infra/bgp/test/ui/views/bgpGridView.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/infra/bgp/test/ui/views/bgpGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.BGP_GRID_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/config/infra/bgp/ui/js/views/bgpListView.js
+++ b/webroot/config/infra/bgp/ui/js/views/bgpListView.js
@@ -73,8 +73,8 @@ define([
                     {
                         columns: [
                             {
-                                elementId: ctwl.CONFIG_LINK_LOCAL_SERVICES_ID,
-                                title: ctwl.TITLE_LINK_LOCAL_SERVICES,
+                                elementId: ctwl.CONFIG_BGP_SECTION_ID,
+                                title: ctwl.TITLE_BGP,
                                 view: "bgpGridView",
                                 viewPathPrefix: "config/infra/bgp/ui/js/views/",
                                 app: cowc.APP_CONTRAIL_CONTROLLER,

--- a/webroot/config/networking/networks/ui/js/views/vnCfgEditView.js
+++ b/webroot/config/networking/networks/ui/js/views/vnCfgEditView.js
@@ -56,6 +56,7 @@ define([
                                          false);
                 Knockback.applyBindings(self.model,
                                         document.getElementById(modalId));
+                //How it knows which collection (network_ipam_refs) to be bound to which element??
                 kbValidation.bind(self,
                     {collection: self.model.model().attributes.network_ipam_refs});
                 kbValidation.bind(self,

--- a/webroot/config/networking/policy/ui/js/policy.main.js
+++ b/webroot/config/networking/policy/ui/js/policy.main.js
@@ -19,7 +19,7 @@ function ConfigPoliciesLoader() {
             if(contrail.checkIfExist(loadingStartedDefObj)) {
                 loadingStartedDefObj.resolve();
             }
-        });
+        })
     }
     this.renderView = function (renderFn, hashParams) {
         $(contentContainer).html("");

--- a/webroot/config/networking/port/test/ui/views/portGridView.test.js
+++ b/webroot/config/networking/port/test/ui/views/portGridView.test.js
@@ -3,13 +3,14 @@
  */
 
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/networking/port/test/ui/views/portGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PORT_GRID_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/config/networking/routeaggregate/test/ui/views/routeAggregateGridView.test.js
+++ b/webroot/config/networking/routeaggregate/test/ui/views/routeAggregateGridView.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/networking/routeaggregate/test/ui/views/routeAggregateGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.ROUTE_AGGREGATE_GRID_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/config/physicaldevices/interfaces/test/ui/views/interfacesGridView.test.js
+++ b/webroot/config/physicaldevices/interfaces/test/ui/views/interfacesGridView.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/physicaldevices/interfaces/test/ui/views/interfacesGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PHYSICAL_INTERFACES_GRID_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/config/physicaldevices/physicalrouters/test/ui/views/physicalRoutersGridView.test.js
+++ b/webroot/config/physicaldevices/physicalrouters/test/ui/views/physicalRoutersGridView.test.js
@@ -3,13 +3,14 @@
  */
 
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/physicaldevices/physicalrouters/test/ui/views/physicalRoutersGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PHYSICAL_ROUTERS_GRID_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/config/services/bgpasaservice/test/ui/views/bgpAsAServiceGridView.test.js
+++ b/webroot/config/services/bgpasaservice/test/ui/views/bgpAsAServiceGridView.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'config/services/bgpasaservice/test/ui/views/bgpAsAServiceGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.BGP_AS_A_SERVICE_GRID_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeDetailPageView.js
@@ -98,6 +98,7 @@ define([
             title: ctwl.TITLE_DETAILS,
             view: "AnalyticsNodeDetailsChartsView",
             viewPathPrefix : ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
             viewConfig: viewConfig
         }
     }

--- a/webroot/monitor/infrastructure/common/ui/js/monitor.infra.init.js
+++ b/webroot/monitor/infrastructure/common/ui/js/monitor.infra.init.js
@@ -10,8 +10,8 @@ define([
         initStatus = contentHandler.initFeatureModuleMap[initJSpath],
         deferredObj = initStatus['deferredObj'];
 
-    initStatus['isInProgress'] = false;
-    initStatus['isComplete'] = true;
+        initStatus['isInProgress'] = false;
+        initStatus['isComplete'] = true;
 
     if(contrail.checkIfExist(deferredObj)) {
         deferredObj.resolve();

--- a/webroot/monitor/infrastructure/common/ui/js/monitor.infra.module.js
+++ b/webroot/monitor/infrastructure/common/ui/js/monitor.infra.module.js
@@ -11,7 +11,8 @@ define([
     'text!controller-basedir/monitor/infrastructure/common/ui/templates/monitor.infra.tmpl',
     'monitor-infra-utils',
     'monitor-infra-constants',
-    'monitor-infra-parsers'
+    'monitor-infra-parsers',
+    'controller-init'
 ], function (MonitorInfraTmpls, MonitorInfraUtils, MonitorInfraConstants, MonitorInfraParsers) {
     monitorInfraConstants = new MonitorInfraConstants;
     monitorInfraUtils = new MonitorInfraUtils;

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers.js
@@ -2,8 +2,9 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define(
-       [ 'underscore' ],
-       function(_) {
+       [ 'underscore' ,
+        'core-alarm-utils'],
+       function(_,coreAlarmUtils) {
             var MonInfraParsers = function() {
                 var self = this;
                 var noDataStr = monitorInfraConstants.noDataStr;

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.utils.js
@@ -1,10 +1,8 @@
 define([
     'underscore',
     'contrail-list-model',
-    'core-basedir/js/views/LoginWindowView',
-    'core-basedir/js/models/LoginWindowModel',
-    'monitor/infrastructure/common/ui/js/views/MonitorInfraObjectLogsPopUpView'
-], function (_, ContrailListModel, LoginWindowView, LoginWindowModel, MonitorInfraObjectLogsPopUpView) {
+    'core-alarm-utils'
+], function (_, ContrailListModel,coreAlarmUtils) {
     var MonitorInfraUtils = function () {
         var self = this;
         var noDataStr = monitorInfraConstants.noDataStr;
@@ -1478,28 +1476,30 @@ define([
         }
 
         self.onStatusLinkClick = function (nodeIp) {
-            var loginWindow = new LoginWindowView();
             var leftColumnContainer = '#left-column-container';
-            loginWindow.model = new LoginWindowModel();
-            loginWindow.renderLoginWindow({
-                data:{
-                    ip: nodeIp
-                },
-                callback : function (response) {
-                    var htmlString = '<pre>' +
-                        response + '</pre>';
-                    $('.contrail-status-view')
-                        .html(htmlString);
-                    $(leftColumnContainer)
-                        .find('.widget-box')
-                        .find('.list-view').hide();
-                    $(leftColumnContainer)
-                        .find('.widget-box')
-                        .find('.advanced-view').hide();
-                    $(leftColumnContainer)
-                        .find('.widget-box')
-                        .find('.contrail-status-view').show();
-                }
+            require(['core-basedir/js/views/LoginWindowView','loginwindow-model'],function(LoginWindowView,LoginWindowModel) {
+                var loginWindow = new LoginWindowView();
+                loginWindow.model = new LoginWindowModel();
+                loginWindow.renderLoginWindow({
+                    data:{
+                        ip: nodeIp
+                    },
+                    callback : function (response) {
+                        var htmlString = '<pre>' +
+                            response + '</pre>';
+                        $('.contrail-status-view')
+                            .html(htmlString);
+                        $(leftColumnContainer)
+                            .find('.widget-box')
+                            .find('.list-view').hide();
+                        $(leftColumnContainer)
+                            .find('.widget-box')
+                            .find('.advanced-view').hide();
+                        $(leftColumnContainer)
+                            .find('.widget-box')
+                            .find('.contrail-status-view').show();
+                    }
+                });
             });
         }
 
@@ -1994,7 +1994,7 @@ define([
                     fromTimeUTC:'now-2h',
                     toTimeUTC:'now',
                     async:true,
-                    queryId: qewu.generateQueryUUID(),
+                    queryId: generateQueryUUID(),
                     reRunTimeRange:600,
                     select:'Source, T, cpu_info.cpu_share, cpu_info.mem_res, cpu_info.module_id',
                     groupFields:['Source'],
@@ -2241,11 +2241,13 @@ define([
             };
         }
         self.showObjLogs = function (objId,type) {
-            var monInfraObjLogsView = new MonitorInfraObjectLogsPopUpView ();
-            monInfraObjLogsView.render ({
-                                        type: type,
-                                        objId: objId
-                                    });
+            require(['monitor/infrastructure/common/ui/js/views/MonitorInfraObjectLogsPopUpView'],function(MonitorInfraObjectLogsPopUpView) {
+                var monInfraObjLogsView = new MonitorInfraObjectLogsPopUpView ();
+                monInfraObjLogsView.render ({
+                                            type: type,
+                                            objId: objId
+                                        });
+            });
         };
 
         self.purgeAnalyticsDB = function (purgePercentage) {

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeDetailPageView.js
@@ -96,6 +96,7 @@ define([
             title: ctwl.TITLE_DETAILS,
             view: "ConfigNodeDetailsChartsView",
             viewPathPrefix : ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
             viewConfig: viewConfig
         }
     }

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeDetailPageView.js
@@ -51,6 +51,7 @@ define([
             title: ctwl.TITLE_DETAILS,
             view: "ControlNodeDetailsChartsView",
             viewPathPrefix : ctwl.CONTROLNODE_VIEWPATH_PREFIX,
+            app: cowc.APP_CONTRAIL_CONTROLLER,
             viewConfig: viewConfig
         }
     }

--- a/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeRoutesFormView.js
+++ b/webroot/monitor/infrastructure/controlnode/ui/js/views/ControlNodeRoutesFormView.js
@@ -48,8 +48,6 @@ define([
             var transportCfg = {
                     url: contrail.format(monitorInfraConstants.monitorInfraUrls['CONTROLNODE_ROUTE_INST_LIST'], hostname, 40)
                 };
-            var routingInstanceDS = new ContrailDataView();
-            getOutputByPagination(routingInstanceDS,{transportCfg:transportCfg,parseFn:parseRoutingInstanceResp});
             if (widgetConfig !== null) {
                 self.renderView4Config($(self.$el).find(routesFormId),
                         self.model, widgetConfig, null, null, null);

--- a/webroot/monitor/infrastructure/dashboard/ui/js/views/ControllerDashboardView.js
+++ b/webroot/monitor/infrastructure/dashboard/ui/js/views/ControllerDashboardView.js
@@ -37,11 +37,11 @@ define([
     });
 
     function getInfoboxesConfig() {
+        var vRouterListModel = new VRouterListModel();
         var analyticsNodeListModel = new AnalyticsNodeListModel();
         var controlNodeListModel = new ControlNodeListModel();
         var databaseNodeListModel = new DatabaseNodeListModel();
         var configNodeListModel = new ConfigNodeListModel();
-        var vRouterListModel = new VRouterListModel();
 
         return [{
             title: 'Virtual Routers',

--- a/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeDetailPageView.js
+++ b/webroot/monitor/infrastructure/databasenode/ui/js/views/DatabaseNodeDetailPageView.js
@@ -82,6 +82,7 @@ define([
             elementId: 'database_detail_charts_id',
             title: ctwl.TITLE_DETAILS,
             view: "DatabaseNodeDetailsChartsView",
+            app: cowc.APP_CONTRAIL_CONTROLLER,
             viewPathPrefix : ctwl.DATABASENODE_VIEWPATH_PREFIX,
             viewConfig: viewConfig
         }

--- a/webroot/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel.js
+++ b/webroot/monitor/infrastructure/underlay/ui/js/models/SearchFlowFormModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var SearchFlowFormModel = QueryFormModel.extend({
         defaultSelectFields: ['flow_class_id', 'direction_ing'],
 

--- a/webroot/monitor/infrastructure/vrouter/ui/js/views/VRouterCrossFiltersView.js
+++ b/webroot/monitor/infrastructure/vrouter/ui/js/views/VRouterCrossFiltersView.js
@@ -6,7 +6,8 @@ define([
     'underscore',
     'backbone',
     'contrail-view',
-    'barchart-cf'
+    // 'barchart-cf'
+    "core-basedir/js/views/BarChartView"
 ], function (_, Backbone,ContrailView,BarChartView) {
     //Takes an array of barChart configuration and renders
     var VRouterCrossFiltersView  = ContrailView.extend({

--- a/webroot/monitor/infrastructure/vrouter/ui/js/views/VRouterDetailPageView.js
+++ b/webroot/monitor/infrastructure/vrouter/ui/js/views/VRouterDetailPageView.js
@@ -73,6 +73,7 @@ define([
             elementId: 'vrouter_detail_charts_id',
             title: ctwl.TITLE_DETAILS,
             view: "VRouterDetailsChartsView",
+            app: cowc.APP_CONTRAIL_CONTROLLER,
             viewPathPrefix : ctwl.VROUTER_VIEWPATH_PREFIX,
             viewConfig: viewConfig
         }

--- a/webroot/monitor/infrastructure/vrouter/ui/js/views/VRouterInterfacesGridView.js
+++ b/webroot/monitor/infrastructure/vrouter/ui/js/views/VRouterInterfacesGridView.js
@@ -105,8 +105,7 @@ define([
                            events: {
                               onClick: function(e,dc) {
                                 if(dc['vm_name'] != null && dc['vm_name'].trim() != '' && viewConfig['isUnderlayPage'] != true) {
-                                  setInstanceURLHashParams(null, dc['vn_name'], dc['vm_uuid'], true);
-                                  //layoutHandler.setURLHashParams({vmName:dc['vm_name'],fqName:dc['vm_uuid'],srcVN:dc['vn_name']},{p:'mon_networking_instances',merge:false,triggerHashChange:true});
+                                  ctwu.setInstanceURLHashParams(null, dc['vn_name'], dc['vm_uuid'], true);
                                 }
                               }
                            },

--- a/webroot/monitor/networking/test/ui/unit/nm.unit.test.js
+++ b/webroot/monitor/networking/test/ui/unit/nm.unit.test.js
@@ -1,4 +1,5 @@
 define([
+    'co-test-constants',
     'co-test-runner',
     'co-test-utils',
     'ct-test-messages',
@@ -6,7 +7,7 @@ define([
     'nm-parsers-unit-test-suite',
     'monitor/networking/test/ui/unit/nm.utils.mock.data',
     'nm-utils-unit-test-suite',
-], function (cotr, cotu, cttm, NMParsersUnitMockData, NMParsersUnitTestSuite, NMUtilsMockData, NMUtilsUnitTestSuite) {
+], function (cotc, cotr, cotu, cttm, NMParsersUnitMockData, NMParsersUnitTestSuite, NMUtilsMockData, NMUtilsUnitTestSuite) {
 
     var moduleId = cttm.NM_UNIT_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/DashboardView.test.js
+++ b/webroot/monitor/networking/test/ui/views/DashboardView.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/DashboardView.mock.data',
     'co-tabs-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/DashboardViewInstances.test.js
+++ b/webroot/monitor/networking/test/ui/views/DashboardViewInstances.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/DashboardView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/DashboardViewInterfaces.test.js
+++ b/webroot/monitor/networking/test/ui/views/DashboardViewInterfaces.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/DashboardView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/DashboardViewNetworks.test.js
+++ b/webroot/monitor/networking/test/ui/views/DashboardViewNetworks.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/DashboardView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/DashboardViewPortDistribution.test.js
+++ b/webroot/monitor/networking/test/ui/views/DashboardViewPortDistribution.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/DashboardView.mock.data',
     'co-chart-view-zoom-scatter-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, ZoomScatterChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, ZoomScatterChartViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/FlowGridView.test.js
+++ b/webroot/monitor/networking/test/ui/views/FlowGridView.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/FlowGridView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/FlowListView.test.js
+++ b/webroot/monitor/networking/test/ui/views/FlowListView.test.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
@@ -9,7 +10,7 @@ define([
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InstanceListView.test.js
+++ b/webroot/monitor/networking/test/ui/views/InstanceListView.test.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
@@ -9,7 +10,7 @@ define([
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite) {
 
     var moduleId = cttm.INSTANCES_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InstanceView.test.js
+++ b/webroot/monitor/networking/test/ui/views/InstanceView.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/InstanceView.mock.data',
     'co-tabs-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
 
     var moduleId = cttm.INSTANCE_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InstanceViewCPUMemory.test.js
+++ b/webroot/monitor/networking/test/ui/views/InstanceViewCPUMemory.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/InstanceView.mock.data',
     'co-chart-view-line-bar-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, LineBarChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, LineBarChartViewTestSuite) {
 
     var moduleId = cttm.INSTANCE_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InstanceViewDetails.test.js
+++ b/webroot/monitor/networking/test/ui/views/InstanceViewDetails.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/InstanceView.mock.data',
     'co-details-view-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, TabsViewTestSuite, DetailsViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, TabsViewTestSuite, DetailsViewTestSuite) {
 
     var moduleId = cttm.INSTANCE_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InstanceViewInterfaces.test.js
+++ b/webroot/monitor/networking/test/ui/views/InstanceViewInterfaces.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/InstanceView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.INSTANCE_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InstanceViewTrafficStatistics.test.js
+++ b/webroot/monitor/networking/test/ui/views/InstanceViewTrafficStatistics.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/InstanceView.mock.data',
     'co-chart-view-line-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, LineWithFocusChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, LineWithFocusChartViewTestSuite) {
 
     var moduleId = cttm.INSTANCE_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/InterfaceListView.test.js
+++ b/webroot/monitor/networking/test/ui/views/InterfaceListView.test.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
@@ -9,7 +10,7 @@ define([
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite) {
 
     var moduleId = cttm.INTERFACES_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/NetworkListView.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkListView.test.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
@@ -10,7 +11,7 @@ define([
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite',
     'network-list-view-custom-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite,
+], function (cotc,cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite,
              CustomTestSuite) {
 
     var moduleId = cttm.NETWORKS_LIST_VIEW_COMMON_TEST_MODULE;

--- a/webroot/monitor/networking/test/ui/views/NetworkView.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkView.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/NetworkView.mock.data',
     'co-tabs-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/NetworkViewDetails.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkViewDetails.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/NetworkView.mock.data',
     'co-details-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, DetailsViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, DetailsViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/NetworkViewInstances.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkViewInstances.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/NetworkView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/NetworkViewInterfaces.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkViewInterfaces.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/NetworkView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/NetworkViewPortDistribution.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkViewPortDistribution.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/NetworkView.mock.data',
     'co-chart-view-zoom-scatter-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, ZoomScatterChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, ZoomScatterChartViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/NetworkViewTrafficStatistics.test.js
+++ b/webroot/monitor/networking/test/ui/views/NetworkViewTrafficStatistics.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/NetworkView.mock.data',
     'co-chart-view-line-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, LineWithFocusChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, LineWithFocusChartViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/ProjectListView.test.js
+++ b/webroot/monitor/networking/test/ui/views/ProjectListView.test.js
@@ -2,6 +2,7 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
@@ -9,7 +10,7 @@ define([
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite',
     'co-chart-view-zoom-scatter-test-suite',
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite, ZoomScatterChartTestSuite) {
 
     var moduleId = cttm.PROJECTS_LIST_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/ProjectView.test.js
+++ b/webroot/monitor/networking/test/ui/views/ProjectView.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2015 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/ProjectView.mock.data',
     'co-tabs-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, TabsViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/ProjectViewInstances.test.js
+++ b/webroot/monitor/networking/test/ui/views/ProjectViewInstances.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/ProjectView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/ProjectViewInterfaces.test.js
+++ b/webroot/monitor/networking/test/ui/views/ProjectViewInterfaces.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/ProjectView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/ProjectViewNetworks.test.js
+++ b/webroot/monitor/networking/test/ui/views/ProjectViewNetworks.test.js
@@ -2,13 +2,14 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/ProjectView.mock.data',
     'co-grid-contrail-list-model-test-suite',
     'co-grid-view-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, GridListModelTestSuite, GridViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/monitor/networking/test/ui/views/ProjectViewPortDistribution.test.js
+++ b/webroot/monitor/networking/test/ui/views/ProjectViewPortDistribution.test.js
@@ -2,12 +2,13 @@
  * Copyright (c) 2016 Juniper Networks, Inc. All rights reserved.
  */
 define([
+    'co-test-constants',
     'co-test-runner',
     'ct-test-utils',
     'ct-test-messages',
     'monitor/networking/test/ui/views/ProjectView.mock.data',
     'co-chart-view-zoom-scatter-test-suite'
-], function (cotr, cttu, cttm, TestMockdata, ZoomScatterChartViewTestSuite) {
+], function (cotc, cotr, cttu, cttm, TestMockdata, ZoomScatterChartViewTestSuite) {
 
     var moduleId = cttm.PROJECTS_VIEW_COMMON_TEST_MODULE;
 

--- a/webroot/reports/qe/ui/js/models/FlowRecordFormModel.js
+++ b/webroot/reports/qe/ui/js/models/FlowRecordFormModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var FormRecordFormModel = QueryFormModel.extend({
 
         defaultSelectFields: ['direction_ing'],

--- a/webroot/reports/qe/ui/js/models/FlowSeriesFormModel.js
+++ b/webroot/reports/qe/ui/js/models/FlowSeriesFormModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var FormSeriesFormModel = QueryFormModel.extend({
 
         defaultSelectFields: ['flow_class_id', 'direction_ing'],

--- a/webroot/reports/qe/ui/js/models/ObjectLogsFormModel.js
+++ b/webroot/reports/qe/ui/js/models/ObjectLogsFormModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var ObjectLogsFormModel = QueryFormModel.extend({
 
         defaultSelectFields: [],

--- a/webroot/reports/qe/ui/js/models/StatQueryFormModel.js
+++ b/webroot/reports/qe/ui/js/models/StatQueryFormModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var StatQueryFormModel = QueryFormModel.extend({
 
         defaultSelectFields: [],

--- a/webroot/reports/qe/ui/js/models/SystemLogsFormModel.js
+++ b/webroot/reports/qe/ui/js/models/SystemLogsFormModel.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'knockout',
-    'query-form-model'
-], function (_, Knockout, QueryFormModel) {
+    'query-form-model',
+    'core-basedir/js/common/qe.model.config'
+], function (_, Knockout, QueryFormModel,qewmc) {
     var SystemLogsFormModel = QueryFormModel.extend({
 
         defaultSelectFields: ["Type"],

--- a/webroot/reports/qe/ui/js/views/FlowRecordFormView.js
+++ b/webroot/reports/qe/ui/js/views/FlowRecordFormView.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'query-form-view',
     'knockback',
-    'controller-basedir/reports/qe/ui/js/models/FlowRecordFormModel'
-], function (_, QueryFormView, Knockback, FlowRecordFormModel) {
+    'controller-basedir/reports/qe/ui/js/models/FlowRecordFormModel',
+    'core-basedir/js/common/qe.utils'
+], function (_, QueryFormView, Knockback, FlowRecordFormModel,qewu) {
 
     var FlowRecordQueryView = QueryFormView.extend({
         render: function () {

--- a/webroot/reports/qe/ui/js/views/FlowSeriesFormView.js
+++ b/webroot/reports/qe/ui/js/views/FlowSeriesFormView.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'query-form-view',
     'knockback',
-    'controller-basedir/reports/qe/ui/js/models/FlowSeriesFormModel'
-], function (_, QueryFormView, Knockback, FlowSeriesFormModel) {
+    'controller-basedir/reports/qe/ui/js/models/FlowSeriesFormModel',
+    'core-basedir/js/common/qe.utils',
+], function (_, QueryFormView, Knockback, FlowSeriesFormModel,qewu) {
 
     var FlowSeriesFormView = QueryFormView.extend({
         render: function () {

--- a/webroot/reports/qe/ui/js/views/ObjectLogsFormView.js
+++ b/webroot/reports/qe/ui/js/views/ObjectLogsFormView.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'query-form-view',
     'knockback',
-    'controller-basedir/reports/qe/ui/js/models/ObjectLogsFormModel'
-], function (_, QueryFormView, Knockback, ObjectLogsFormModel) {
+    'controller-basedir/reports/qe/ui/js/models/ObjectLogsFormModel',
+    'core-basedir/js/common/qe.utils',
+], function (_, QueryFormView, Knockback, ObjectLogsFormModel,qewu) {
 
     var ObjectLogsFormView = QueryFormView.extend({
         render: function () {

--- a/webroot/reports/qe/ui/js/views/QueryQueueView.js
+++ b/webroot/reports/qe/ui/js/views/QueryQueueView.js
@@ -5,8 +5,9 @@
 define([
     'underscore',
     'contrail-view',
-    'contrail-list-model'
-], function (_, ContrailView, ContrailListModel) {
+    'contrail-list-model',
+    'core-basedir/js/common/qe.grid.config'
+], function (_, ContrailView, ContrailListModel,qewgc) {
     var QueryQueueView = ContrailView.extend({
         render: function () {
             var self = this,

--- a/webroot/reports/qe/ui/js/views/StatQueryFormView.js
+++ b/webroot/reports/qe/ui/js/views/StatQueryFormView.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'query-form-view',
     'knockback',
-    'controller-basedir/reports/qe/ui/js/models/StatQueryFormModel'
-], function (_, QueryFormView, Knockback, StatQueryFormModel) {
+    'controller-basedir/reports/qe/ui/js/models/StatQueryFormModel',
+    'core-basedir/js/common/qe.utils'
+], function (_, QueryFormView, Knockback, StatQueryFormModel,qewu) {
 
     var StatQueryFormView = QueryFormView.extend({
         render: function () {

--- a/webroot/reports/qe/ui/js/views/SystemLogsFormView.js
+++ b/webroot/reports/qe/ui/js/views/SystemLogsFormView.js
@@ -6,8 +6,9 @@ define([
     'underscore',
     'query-form-view',
     'knockback',
-    'controller-basedir/reports/qe/ui/js/models/SystemLogsFormModel'
-], function (_, QueryFormView, Knockback, SystemLogsFormModel) {
+    'controller-basedir/reports/qe/ui/js/models/SystemLogsFormModel',
+    'core-basedir/js/common/qe.utils'
+], function (_, QueryFormView, Knockback, SystemLogsFormModel,qewu) {
 
     var SystemLogsFormView = QueryFormView.extend({
         render: function () {


### PR DESCRIPTION
Performance changes for improving the loading time
1. Changes to load all files via require (Removed contrail-unified-*.js files and other files in dashboard.tmpl that are loaded via <script> tags)
    Problem with loading files via <script> tag is that they don't give control to wait for that module using (require()) when that module is referenced in other modules.
    So,to ensure that the module is available,we need to delay the loading of modules dependent on it and that leads to waterfall pattern in loading
2. Merged login.tmpl and dashboard.tmpl to have a single HTML file
    So, all authenticate,logout requests are issued via XMLHttpRequests and changes done on backend to respond accordingly
    Changes to swap between login container and app container based on authenticated or not
    Making it a single-page app,gives the provision to prefetch and intitalize files/bundles even before authenticate itself such that view can be rendered as soon as user clicks on "Sign In"
3. Provision to load even feature bundles before login itself
4. Enabled gzip compression for .xml & .tmpl files
5. Created the following bundles
    * core.bundle
    * nonamd.libs       #All third-party/libraries that don't define modules and export to global
    * chart.libs        #d3,nvd3
    * jquery.dep.libs   #Libraries that depend on jQuery
    * thirdparty.libs   #Libraries that can be lazy loaded and not required for landing page,dashboard
    * contrail.core.views   #All Contrail views
6. Removed exporting qe/alarm modules in global scope and included the files whereever required.
    As these files are required in multiple files,made the modules to return singleton instance
8. Updated test scripts with to comply with the changes in loading files
9. Required "co-test-constants" in test files to access ctoc instead of referring from global scope

Ran the test cases for all repos (serverManager,Storage,Controller) in
both prod-env and dev-env and all tests passed

Change-Id: I350768bae51074965858b61f2802a6e2957637bb