### PR TITLE
Closes-Bug: #1574964 - Whenever the forcerefresh used to fail or time…

### DIFF
--- a/webroot/monitor/infrastructure/common/ui/js/models/VRouterListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/VRouterListModel.js
@@ -36,11 +36,14 @@ define(['contrail-list-model'], function(ContrailListModel) {
                     var fetchContrailListModel = new ContrailListModel({
                         remote : {
                             ajaxConfig : {
-                                url : monitorInfraConstants.monitorInfraUrls.VROUTER_CACHED_SUMMARY + '?forceRefresh'
+                                url : monitorInfraConstants.monitorInfraUrls.VROUTER_CACHED_SUMMARY + '?forceRefresh',
+                                timeout : 300000 // 5 mins as this may take more time with more nodes
                             },
                             onAllRequestsCompleteCB: function(fetchedContrailListModel) {
                                 var data = fetchedContrailListModel.getItems();
-                                contrailListModel.setData(data);
+                                if(!fetchedContrailListModel.error) {
+                                    contrailListModel.setData(data);
+                                }
                             },
                             dataParser : monitorInfraParsers.parsevRoutersDashboardData,
                         },


### PR DESCRIPTION
…out the

original data gotten by servercache or localcache would get removed. To avoid
this added a check to update the model only if there is no error in the
forcerefresh call.
Increased the timeout of the force refresh call to 5 minutes.

Change-Id: I1bfa9701a69c55ac21ea8cce008e0d1fd1b59750