### PR TITLE
Closes-Bug: #1599319

### DIFF
--- a/webroot/monitor/networking/ui/js/views/MonitorNetworkingView.js
+++ b/webroot/monitor/networking/ui/js/views/MonitorNetworkingView.js
@@ -100,8 +100,9 @@ define([
         var hashParams = viewConfig.hashParams,
             customProjectDropdownOptions = {
                 getProjectsFromIdentity: true,
+                defaultValueIndex: 1,
                 childView: {
-                    init: getNetworkListViewConfig(viewConfig),
+                    init: getNetworkListViewConfig(viewConfig)
                 },
                 allDropdownOption: ctwc.ALL_PROJECT_DROPDOWN_OPTION
             },
@@ -148,6 +149,7 @@ define([
     function getInstanceListConfig(viewConfig) {
         var hashParams = viewConfig.hashParams,
             customNetworkDropdownOptions = {
+                defaultValueIndex: 1,
                 childView: {
                     init: getInstanceListViewConfig(viewConfig)
                 },
@@ -155,6 +157,7 @@ define([
             },
             customProjectDropdownOptions = {
                 getProjectsFromIdentity: true,
+                defaultValueIndex: 1,
                 childView: {
                     init: ctwvc.getNetworkBreadcrumbDropdownViewConfig(hashParams, customNetworkDropdownOptions),
                 },


### PR DESCRIPTION
- Added defaultValueIndex option inside BreadcrumbDropdownView to specify the index of option to be selected when there is no url and cookie value.
- Added defaultValueIndex to 1 for MN List pages to avoid performance hit at the backend.

Change-Id: I4e1c312c5ea88019306aeb0cb9c42009327f58d0