### PR TITLE
Removed Extra call to get shared networks using is_shared=true

### DIFF
--- a/webroot/config/services/instances/ui/js/views/svcInstEditView.js
+++ b/webroot/config/services/instances/ui/js/views/svcInstEditView.js
@@ -145,10 +145,6 @@ define([
                     },
                     {
                         'type': 'route-aggregates'
-                    },
-                    {
-                        'type': 'virtual-networks',
-                        'filters': 'is_shared==true'
                     }]}
                 });
             if ((null != setVNList) && (setVNList.length > 0)) {


### PR DESCRIPTION
Below Manual Test cases are passed

1)Check for duplicates in vn dropdown in service instance create

Change-Id: I8025e87c36afeb00b59e98cc6f611ab1e2a6bad5
Closes-bug: #1609726