### PR TITLE
Graph.utils no more part of global scope.

### DIFF
--- a/webroot/monitor/networking/ui/js/views/NetworkingGraphView.js
+++ b/webroot/monitor/networking/ui/js/views/NetworkingGraphView.js
@@ -7,8 +7,9 @@ define([
     'contrail-view',
     'contrail-graph-model',
     'graph-view',
-    'contrail-element'
-], function (_, ContrailView, ContrailGraphModel, GraphView, ContrailElement) {
+    'contrail-element',
+    'core-basedir/js/common/graph.utils'
+], function (_, ContrailView, ContrailGraphModel, GraphView, ContrailElement, grUtils) {
 
     var NetworkingGraphView = ContrailView.extend({
         render: function () {


### PR DESCRIPTION
use graph.utils locally by requiring

Change-Id: I1b85d5c1361639808f48c725708100c1238113c4