### PR TITLE
Update viewconfig app param for QE views

### DIFF
--- a/webroot/reports/qe/ui/js/views/ControllerQEView.js
+++ b/webroot/reports/qe/ui/js/views/ControllerQEView.js
@@ -100,7 +100,6 @@ define([
                         elementId: cowl.QE_FLOW_QUEUE_ID,
                         view: "QueryQueueView",
                         viewPathPrefix: "reports/qe/ui/js/views/",
-                        app: cowc.APP_CONTRAIL_CONTROLLER,
                         viewConfig: {
                             queueType: queueType
                         }


### PR DESCRIPTION
- QueryQueueView is part of core repo.
No need to specify the app for core views to renderView

Change-Id: I330800bb12c9643f39c72dc77b54ae2a2b942f02
Related-Bug: #1632550