### PR TITLE
Related-Bug:#1633013

### DIFF
--- a/webroot/common/ui/js/controller.labels.js
+++ b/webroot/common/ui/js/controller.labels.js
@@ -391,6 +391,9 @@ define([
         this.CACHE_DATABASE_USAGE_CHARTS = 'cache-databse-usage-charts';
         this.ANALYTICS_CHART_PERCENTILE_SECTION_ID = "analytics-chart-percentile-section-id";
         this.ANALYTICS_CHART_PERCENTILE_TEXT_VIEW = "analytics-chart-percentile-text-view";
+        this.ANALYTICSNODE_CHART_PERCENTILE_TITLE = "95th Percentile - Messages (per min)";
+        this.ANALYTICSNODE_CHART_PERCENTILE_COUNT = "Count";
+        this.ANALYTICSNODE_CHART_PERCENTILE_SIZE = "Size";
         //Config node labels
         this.CONFIGNODE_VIEWPATH_PREFIX = 'monitor/infrastructure/confignode/ui/js/views/';
         this.CONFIGNODE_SUMMARY_PAGE_ID = 'monitor-config-nodes';
@@ -406,6 +409,11 @@ define([
         this.CONFIGNODE_SUMMARY_CHART_ID = 'config-nodes-chart';
         this.CONFIGNODE_SUMMARY_LIST_SECTION_ID = 'config-nodes-list-section';
         this.CONFIGNODE_SUMMARY_CHART_SECTION_ID = 'config-nodes-chart-section';
+        this.CONFIGNODE_CHART_PERCENTILE_SECTION_ID = "confignode-chart-percentile-section-id";
+        this.CONFIGNODE_CHART_PERCENTILE_TEXT_VIEW = "confignode-chart-percentile-text-view";
+        this.CONFIGNODE_CHART_PERCENTILE_TITLE = "95th Percentile - Response";
+        this.CONFIGNODE_CHART_PERCENTILE_TIME = "Time";
+        this.CONFIGNODE_CHART_PERCENTILE_SIZE = "Size";
         //Config node scatter chart
         this.CONFIGNODE_SUMMARY_SCATTERCHART_ID = 'config-nodes-scatterchart';
         this.CONFIGNODE_SUMMARY_SCATTERCHART_SECTION_ID = 'config-nodes-scatterchart-section';

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeListView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeListView.js
@@ -9,10 +9,9 @@ define(
                 _, ContrailView, AnalyticsNodeListModel, NodeColorMapping) {
             var AnalyticsNodeListView = ContrailView.extend({
                 render : function() {
-                    var analyticsNodeListModel = new AnalyticsNodeListModel();
                     nodeColorMapping = new NodeColorMapping(),
                     colorFn = nodeColorMapping.getNodeColorMap;
-                    this.renderView4Config(this.$el, analyticsNodeListModel,
+                    this.renderView4Config(this.$el, null,
                             getAnalyticsNodeListViewConfig(colorFn));
                 }
             });
@@ -20,34 +19,262 @@ define(
             function getAnalyticsNodeListViewConfig(colorFn) {
                 var viewConfig = {
                         rows : [
-                            {
-                                columns : [{
-                                    elementId :
-                                        ctwl.ANALYTICSNODE_SUMMARY_CHART_ID,
-                                    title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
-                                    view : "AnalyticsNodesSummaryChartsView",
-                                    viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
-                                    app : cowc.APP_CONTRAIL_CONTROLLER,
-                                    viewConfig: {
-                                        colorFn: colorFn
-                                    }
+                                {
+                                    columns : [
+                                               {
+                                        elementId: 'analytics-node-carousel-view',
+                                        view: "CarouselView",
+                                        viewConfig: {
+                                            pages : [
+                                                 {
+                                                     page: {
+                                                         elementId :ctwl.ANALYTICSNODE_SUMMARY_CHART_ID,
+                                                         title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                         view : "AnalyticsNodesSummaryChartsView",
+                                                         viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
+                                                         app : cowc.APP_CONTRAIL_CONTROLLER,
+                                                         viewConfig: {
+                                                             colorFn: colorFn
+                                                         }
+                                                     },
+                                                 },{
+                                                     page: {
+                                                         elementId: 'grid-stack-view-page-1',
+                                                         view: 'GridStackView',
+                                                         viewConfig: {
+                                                             gridAttr: {
+                                                                 defaultWidth: 6,
+                                                                 defaultHeight: 10
+                                                             },
+                                                             widgetCfgList: [
+                                                                   {
+                                                                       modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                           table_name: 'StatTable.SandeshMessageStat.msg_info',
+                                                                           select: 'T=, msg_info.type, SUM(msg_info.messages)'
+                                                                       }),
+                                                                       viewCfg: {
+                                                                           elementId : 'message_type_top_5_section',
+                                                                           view : "SectionView",
+                                                                           viewConfig : {
+                                                                               rows : [ {
+                                                                                   columns :[
+                                                                                        $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                                                                            elementId : 'message_type_top_5',
+                                                                                            viewConfig: {
+                                                                                                chartOptions: {
+                                                                                                    colors: cowc.FIVE_NODE_COLOR,
+                                                                                                    title: 'Message Types',
+                                                                                                    xAxisLabel: '',
+                                                                                                    yAxisLabel: 'Top Message Types',
+                                                                                                    groupBy: 'msg_info.type',
+                                                                                                    limit: 5,
+                                                                                                    yField: 'SUM(msg_info.messages)',
+                                                                                                }
+                                                                                            }
+                                                                                        })
+                                                                                   ]
+                                                                               }]
+                                                                           }
+                                                                       }
+                                                                   },{
+                                                                       modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                           table_name: 'StatTable.SandeshMessageStat.msg_info',
+                                                                           select: 'T=, name, SUM(msg_info.messages)'
+                                                                       }),
+                                                                       viewCfg: {
+                                                                           elementId : 'generator_top_5_section',
+                                                                           view : "SectionView",
+                                                                           viewConfig : {
+                                                                               rows : [ {
+                                                                                   columns :[
+                                                                                        $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                                                                            elementId : 'generator_top_5',
+                                                                                            viewConfig: {
+                                                                                                chartOptions: {
+                                                                                                    colors: cowc.FIVE_NODE_COLOR,
+                                                                                                    title: 'Generators',
+                                                                                                    xAxisLabel: '',
+                                                                                                    yAxisLabel: 'Top Generators',
+                                                                                                    groupBy: 'name',
+                                                                                                    limit: 5,
+                                                                                                    yField: 'SUM(msg_info.messages)',
+                                                                                                }
+                                                                                            }
+                                                                                        })
+                                                                                   ]
+                                                                               }]
+                                                                           }
+                                                                       }
+                                                                   }, {
+                                                                       modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                           table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                           select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                           where: 'process_mem_cpu_usage.__key = contrail-analytics-nodemgr'
+                                                                       }),
+                                                                       viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                           elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                           viewConfig: {
+                                                                               chartOptions: {
+                                                                                   yFormatter: d3.format('.2f'),
+                                                                                   yAxisLabel: 'Node Manager CPU Share (%)',
+                                                                                   groupBy: 'name',
+                                                                                   colors: colorFn,
+                                                                                   yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                                   title: ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                               }
+                                                                           }
+                                                                       })
+                                                                   }, {
+                                                                       modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                           table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                           select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                           where: 'process_mem_cpu_usage.__key = contrail-snmp-collector'
+                                                                       }),
+                                                                       viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                           elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                           viewConfig: {
+                                                                               chartOptions: {
+                                                                                   yFormatter: d3.format('.2f'),
+                                                                                   yAxisLabel: 'SNMP Collector CPU Share (%)',
+                                                                                   groupBy: 'name',
+                                                                                   colors: colorFn,
+                                                                                   yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                                   title: ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                               }
+                                                                           }
+                                                                       })
+                                                                   }, {
+                                                                       modelCfg: new AnalyticsNodeListModel(),
+                                                                       viewCfg: {
+                                                                           elementId :
+                                                                               ctwl.ANALYTICSNODE_SUMMARY_GRID_ID,
+                                                                           title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                           view : "AnalyticsNodeSummaryGridView",
+                                                                           viewPathPrefix:
+                                                                               ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                                                                           app : cowc.APP_CONTRAIL_CONTROLLER,
+                                                                           viewConfig : {
+                                                                               colorFn: colorFn
+                                                                           }},
+                                                                       itemAttr: {
+                                                                           width: 2
+                                                                       }
+                                                                   }
+                                                             ]
+                                                         }
+                                                     }
+                                                 },{
+                                                     page: {
+                                                         elementId: 'grid-stack-view-page-2',
+                                                         view: 'GridStackView',
+                                                         viewConfig: {
+                                                             gridAttr: {
+                                                                 defaultWidth: 6,
+                                                                 defaultHeight: 10
+                                                             },
+                                                             widgetCfgList: [
+                                                                 {
+                                                                     modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                         table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                         select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                         where: 'process_mem_cpu_usage.__key = contrail-alarm-gen'
+                                                                     }),
+                                                                     viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                         elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                         viewConfig: {
+                                                                             chartOptions: {
+                                                                                 yFormatter: d3.format('.2f'),
+                                                                                 yAxisLabel: 'Alarm Generator CPU Share (%)',
+                                                                                 groupBy: 'name',
+                                                                                 colors: colorFn,
+                                                                                 yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                                 title: ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                             }
+                                                                         }
+                                                                     })
+                                                                 },{
+                                                                     modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                         table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                         select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                         where: 'process_mem_cpu_usage.__key = contrail-collector'
+                                                                     }),
+                                                                     viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                         elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                         viewConfig: {
+                                                                             chartOptions: {
+                                                                                 yFormatter: d3.format('.2f'),
+                                                                                 yAxisLabel: 'Collector CPU Share (%)',
+                                                                                 groupBy: 'name',
+                                                                                 colors: colorFn,
+                                                                                 yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                                 title: ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                             }
+                                                                         }
+                                                                     })
+                                                                 },{
+                                                                     modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                         table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                         select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                         where: 'process_mem_cpu_usage.__key = contrail-query-engine'
+                                                                     }),
+                                                                     viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                         elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                         viewConfig: {
+                                                                             chartOptions: {
+                                                                                 yFormatter: d3.format('.2f'),
+                                                                                 yAxisLabel: 'QE CPU Share (%)',
+                                                                                 groupBy: 'name',
+                                                                                 colors: colorFn,
+                                                                                 yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                                 title: ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                             }
+                                                                         }
+                                                                     })
+                                                                 },{
+                                                                     modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                         table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                         select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                         where: 'process_mem_cpu_usage.__key = contrail-analytics-api'
+                                                                     }),
+                                                                     viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                         elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                         viewConfig: {
+                                                                             chartOptions: {
+                                                                                 yFormatter: d3.format('.2f'),
+                                                                                 yAxisLabel: 'Api CPU Share (%)',
+                                                                                 groupBy: 'name',
+                                                                                 colors: colorFn,
+                                                                                 yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                                 title: ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                             }
+                                                                         }
+                                                                     })
+                                                                 },{
+                                                                     modelCfg: new AnalyticsNodeListModel(),
+                                                                     viewCfg: {
+                                                                         elementId :
+                                                                             ctwl.ANALYTICSNODE_SUMMARY_GRID_ID,
+                                                                         title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
+                                                                         view : "AnalyticsNodeSummaryGridView",
+                                                                         viewPathPrefix:
+                                                                             ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                                                                         app : cowc.APP_CONTRAIL_CONTROLLER,
+                                                                         viewConfig : {
+                                                                             colorFn: colorFn
+                                                                         }},
+                                                                     itemAttr: {
+                                                                         width: 2
+                                                                     }
+                                                                 }
+                                                             ]
+                                                         }
+                                                     }
+                                                 }
+                                            ]
+                                        }
+                                    }]
                                 }]
-                            },{
-                                columns : [{
-                                    elementId :
-                                        ctwl.ANALYTICSNODE_SUMMARY_GRID_ID,
-                                    title : ctwl.ANALYTICSNODE_SUMMARY_TITLE,
-                                    view : "AnalyticsNodeSummaryGridView",
-                                    viewPathPrefix:
-                                        ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
-                                    app : cowc.APP_CONTRAIL_CONTROLLER,
-                                    viewConfig : {
-                                        colorFn: colorFn
-                                    }
-                                }]
-                            }
-                            ]
-                        };
+                       };
                 return {
                     elementId : cowu.formatElementId([
                          ctwl.ANALYTICSNODE_SUMMARY_LIST_SECTION_ID ]),

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeSummaryGridView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/AnalyticsNodeSummaryGridView.js
@@ -154,6 +154,20 @@ define([ 'underscore', 'contrail-view' ],function(_, ContrailView) {
                        sortable:true,
                        name:"Generators",
                        minWidth:85
+                   },{
+                       id:"percentileMessagesSize",
+                       sortable:true,
+                       name:"95% - Messages",
+                       minWidth:200,
+                       formatter:function(r,c,v,cd,dc) {
+                           return '<span><b>'+"Count: "+
+                                   '</b></span>' +
+                                  '<span>' +
+                                  (dc['percentileMessages']) + '</span>'+'<span><b>'+", Size: "+
+                                   '</b></span>' +
+                                  '<span>' +
+                                  (dc['percentileSize']) + '</span>';
+                       }
                    }
                 ];
                 var gridElementConfig = {

--- a/webroot/monitor/infrastructure/analyticsnode/ui/js/views/PercentileTextView.js
+++ b/webroot/monitor/infrastructure/analyticsnode/ui/js/views/PercentileTextView.js
@@ -25,10 +25,14 @@ define(['underscore', 'contrail-view', 'contrail-list-model'],
            },
         renderTemplate: function (selector, viewConfig, chartViewModel,percentileTextViewTemplate) {
             var chartModelItems = chartViewModel.getItems(), self = this;
-            var percentileMessagesobjVal = getValueByJsonPath(chartModelItems, '0;percentileMessagesobjVal', '-');
-            var percentileSizeobjVal = getValueByJsonPath(chartModelItems, '0;percentileSizeobjVal', '-');
-            self.$el.html(percentileTextViewTemplate({percentileMessagesobjVal: percentileMessagesobjVal ,percentileSizeobjVal: percentileSizeobjVal}));
-           }
+            var percentileXobjVal = getValueByJsonPath(chartModelItems, '0;percentileXobjVal', '-');
+            var percentileYobjVal = getValueByJsonPath(chartModelItems, '0;percentileYobjVal', '-');
+            self.$el.html(percentileTextViewTemplate({percentileXobjVal: percentileXobjVal,
+                percentileYobjVal: percentileYobjVal,
+                percentileTitle: viewConfig.percentileTitle,
+                percentileYvalue: viewConfig.percentileYvalue,
+                percentileXvalue: viewConfig.percentileXvalue}));
+        }
     });
 
    return PercentileTextView;

--- a/webroot/monitor/infrastructure/common/ui/css/monitor.infra.css
+++ b/webroot/monitor/infrastructure/common/ui/css/monitor.infra.css
@@ -4,22 +4,19 @@
 .mon-infra-chart g.nv-barsWrap g.nv-group {
     fill-opacity: 1 !important;
 }
-#analytics-nodes-chart .contrail-legend text,
-#database-nodes-chart .contrail-legend text,
-#config-nodes-chart .contrail-legend text{
+
+.mon-infra-chart .contrail-legend text{
     font: normal 11px Open Sans;
     opacity: 1;
 }
-#analytics-nodes-chart .contrail-chart-title text,
-#config-nodes-chart .contrail-chart-title text  {
+.mon-infra-chart .contrail-chart-title text  {
     font-size: 11px;
 }
-#config-nodes-chart,
-#analytics-nodes-chart,
-#database-nodes-chart{
-    margin-top:15px !important;
+.mon-infra-chart{
+    margin-left:10px !important;
+    margin-right:10px !important;
 }
-#config-nodes-chart .chart-container g.main text.axis-label,
+/*#config-nodes-chart .chart-container g.main text.axis-label,
 #config-nodes-donutchart-section g.contrail-chart-title text,
 #config-nodes-linebarchart .nv-axislabel{
     text-anchor:middle !important;
@@ -31,9 +28,9 @@
 }
 #config-nodes-linebarchart{
     width:43% !important;
-}
+}*/
 
-.mon-infra-chart .chart-container g.main text.axis-label,
+.mon-infra-chart .chart-container text.axis-label,
 .mon-infra-chart text.nv-axislabel{
     text-anchor:middle;
     font-weight:600;
@@ -57,16 +54,18 @@
 #vrouter_routes_radio .form-element .ace-lbl {
   margin-right: 15px;
 }
+#analytics-chart-percentile-text-view, #confignode-chart-percentile-text-view{
+     width:50% !important;
+}
 /******VRouter Radio Button Css Ends Here****/
 .percentile {
     background: #f6f6f6;
-    padding: 8px 0px;
+    padding: 6px 4px 6px 4px;
     color: #787878;
     font-family: "Open Sans";
     font-size: 11px;
-    margin-left: 62px;
+    margin-left: 0px;
     margin-right: 10px;
-    padding: 10px;
     vertical-align: middle;
 }
 .percentile dl, .percentile dt, .percentile dd {
@@ -127,3 +126,19 @@ dl.progress-percentage dd {
 }
 /******Percentile CSS ends here****/
 
+.grid-stack-item header{
+  background-color:transparent !important;
+  white-space: nowrap;
+  overflow: hidden;
+  text-indent: -1000em !important;
+  color:#fff !important;
+}
+.ui-draggable-handle:hover{
+    cursor:move;
+}
+.grid-stack .grid-stack-item .grid-stack-item-content {
+    overflow: hidden;
+}
+.chart-control-panel-container{
+    display:none !important;
+}

--- a/webroot/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/AnalyticsNodeListModel.js
@@ -52,6 +52,35 @@ define(['contrail-list-model'], function(ContrailListModel) {
                         monitorInfraUtils.parseAndMergeCpuStatsWithPrimaryDataForInfraNodes(
                         response, contrailListModel);
                     }
+                },{
+                    getAjaxConfig : function() {
+                        var queryPostData = {
+                                "autoSort": true,
+                                "async": false,
+                                "formModelAttrs": {
+                                 "table_name": "StatTable.SandeshMessageStat.msg_info",
+                                  "table_type": "STAT",
+                                  "query_prefix": "stat",
+                                  "from_time": Date.now() - (2 * 60 * 60 * 1000),
+                                  "from_time_utc": Date.now() - (2 * 60 * 60 * 1000),
+                                  "to_time": Date.now(),
+                                  "to_time_utc": Date.now(),
+                                  "select": "Source,PERCENTILES(msg_info.bytes), PERCENTILES(msg_info.messages)",
+                                  "time_granularity": 30,
+                                  "time_granularity_unit": "mins",
+                                  "limit": "150000"
+                                },
+                            };
+                        return {
+                            url : "/api/qe/query",
+                            type: 'POST',
+                            data: JSON.stringify(queryPostData)
+                        };
+                    },
+                    successCallback : function(response, contrailListModel) {
+                            monitorInfraUtils.parseAndMergePercentileAnalyticsNodeSummaryChart(
+                                    response['data'], contrailListModel);
+                    }
                 }
                 ]
             },

--- a/webroot/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/ConfigNodeListModel.js
@@ -28,6 +28,36 @@ define([
                     monitorInfraUtils.parseAndMergeCpuStatsWithPrimaryDataForInfraNodes(
                     response, contrailListModel);
                 }
+            },{
+                getAjaxConfig : function() {
+                    var queryPostData = {
+                            "autoSort": true,
+                            "async": false,
+                            "formModelAttrs": {
+                             "table_name": "StatTable.VncApiStatsLog.api_stats",
+                              "table_type": "STAT",
+                              "query_prefix": "stat",
+                              "from_time": Date.now() - (2 * 60 * 60 * 1000),
+                              "from_time_utc": Date.now() - (2 * 60 * 60 * 1000),
+                              "to_time": Date.now(),
+                              "to_time_utc": Date.now(),
+                              "select": "Source,PERCENTILES(api_stats.response_time_in_usec), PERCENTILES(api_stats.response_size)",
+                              "time_granularity": 30,
+                              "time_granularity_unit": "mins",
+                              "limit": "150000"
+                            },
+                        };
+                    return {
+                        url : "/api/qe/query",
+                        type: 'POST',
+                        data: JSON.stringify(queryPostData)
+                    };
+                },
+                successCallback : function(response, contrailListModel) {
+                        monitorInfraUtils.parseAndMergepercentileConfigNodeNodeSummaryChart(
+                                response['data'], contrailListModel);
+
+                }
             }
         ];
         var listModelConfig = {

--- a/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeCPUMemChartModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeCPUMemChartModel.js
@@ -7,7 +7,7 @@ define([
 ], function (ContrailListModel) {
     var CNCPUMemChartsModel = function () {
         var statsConfig = {};
-        statsConfig["tableName"] = "StatTable.ControlCpuState.cpu_info";
+        statsConfig["table_name"] = "StatTable.ControlCpuState.cpu_info";
         statsConfig["select"] = "T=, name, MAX(cpu_info.cpu_share), MAX(cpu_info.mem_res)";
         statsConfig["where"] = "cpu_info.module_id = contrail-control";
         return ContrailListModel(monitorInfraUtils.getStatsModelConfig(statsConfig));

--- a/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeReceivedUpdatesModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeReceivedUpdatesModel.js
@@ -7,7 +7,7 @@ define([
 ], function (ContrailListModel) {
     var CNReceivedUpdatesModel = function () {
         var statsConfig = {};
-        statsConfig["tableName"] = "StatTable.PeerStatsData.rx_update_stats";
+        statsConfig["table_name"] = "StatTable.PeerStatsData.rx_update_stats";
         statsConfig["select"] = "T=, Source, SUM(rx_update_stats.reach), SUM(rx_update_stats.unreach)";
         return ContrailListModel(monitorInfraUtils.getStatsModelConfig(statsConfig));
     };

--- a/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeSentUpdatesModel.js
+++ b/webroot/monitor/infrastructure/common/ui/js/models/ControlNodeSentUpdatesModel.js
@@ -7,7 +7,7 @@ define([
 ], function (ContrailListModel) {
     var CNSentUpdatesModel = function () {
         var statsConfig = {};
-        statsConfig["tableName"] = "StatTable.PeerStatsData.tx_update_stats";
+        statsConfig["table_name"] = "StatTable.PeerStatsData.tx_update_stats";
         statsConfig["select"] = "T=, Source, SUM(tx_update_stats.reach), SUM(tx_update_stats.unreach)";
         return ContrailListModel(monitorInfraUtils.getStatsModelConfig(statsConfig));
     };

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.constants.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.constants.js
@@ -3,8 +3,9 @@
  */
 
 define([
-    'underscore'
-], function (_) {
+    'underscore',
+    'legend-view'
+], function (_, LegendView) {
     var MonitorInfraConstants = function () {
         this.infraNodesTree;
         this.noDataStr = '-';
@@ -137,6 +138,70 @@ define([
                                      { id:"Local", text:"Local" }];
 
         this.VROUTER_DEFAULT_MAX_THROUGHPUT = 10737418240; // 10 GB
+
+        this.stackChartDefaultViewConfig = {
+            view: 'StackedBarChartWithFocusView',
+            viewConfig: {
+                class: 'mon-infra-chart chartMargin',
+                chartOptions: {
+                    bucketSize: this.STATS_BUCKET_DURATION,
+                    showControls: true,
+                    height: 230,
+                    tickPadding: 8,
+                    margin: {
+                        left: 45,
+                        top: 20,
+                        right: 0,
+                        bottom: 40
+                    },
+                    yAxisOffset: 25,
+                    defaultZeroLineDisplay: true
+                }
+            }
+        };
+        this.defaultLineChartViewCfg = {
+                view : "LineWithFocusChartView",
+                viewConfig: {
+                    class: 'mon-infra-chart chartMargin',
+                    chartOptions : {
+                        brush: false,
+                        height: 225,
+                        xAxisLabel: '',
+                        yAxisLabel: '',
+                        groupBy: 'Source',
+                        yField: '',
+                        yFieldOperation: 'average',
+                        bucketSize: this.STATS_BUCKET_DURATION,
+                        colors: {},
+                        title: '',
+                        axisLabelDistance : 0,
+                        margin: {
+                            left: 70,
+                            top: 20,
+                            right: 15,
+                            bottom: 20
+                        },
+                        tickPadding: 8,
+                        hideFocusChart: true,
+                        forceY: false,
+                        yFormatter : d3.format('d'),
+                        xFormatter: function(xValue, tickCnt) {
+                            var date = xValue > 1 ? new Date(xValue) : new Date();
+                            if (tickCnt != null) {
+                               var mins = date.getMinutes();
+                               date.setMinutes(Math.ceil(mins/15) * 15);
+                            }
+                            return d3.time.format('%H:%M')(date);
+                        },
+                        yTickFormat: function(value){
+                            return d3.format('.2f')(value);
+                        },
+                        showLegend: true,
+                        defaultZeroLineDisplay: true,
+                        legendView: LegendView
+                    },
+                }
+            };
 
     };
 

--- a/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers.js
+++ b/webroot/monitor/infrastructure/common/ui/js/utils/monitor.infra.parsers.js
@@ -702,87 +702,27 @@ define(
                     var parsedData = [];
                     var formatBytespercentileSizeVal = formatBytes(percentileSizeobjVal);
                     parsedData.push({
-                        percentileMessagesobjVal: percentileMessagesobjVal,
-                        percentileSizeobjVal: formatBytespercentileSizeVal
+                        percentileXobjVal: percentileMessagesobjVal,
+                        percentileYobjVal: formatBytespercentileSizeVal
                     });
                     return parsedData;
                 };
-
-                this.parseConfigNodeResponseStackedChartData = function (apiStats, colorFn) {
-                    var cf = crossfilter(apiStats);
-                    var buckets = cowu.bucketizeStats(apiStats, {
-                        bucketSize: 4});
-                    var tsDim = cf.dimension(function (d) {return d.T});
-                    var sourceDim = cf.dimension(function (d) {return d.Source});
-                    var sourceGroupedData = sourceDim.group().all();
-                    var sourceGrpKeys = _.pluck(sourceGroupedData, 'key');
-                    var colors = colorFn(_.sortBy(sourceGrpKeys));
-                    var nodeMap = {}, chartData = [];
-                    $.each(sourceGroupedData, function (idx, obj) {
-                        nodeMap[obj['key']] = {
-                            key: obj['key'],
-                            values: [],
-                            bar: true,
-                            color: colors[obj['key']] != null ? colors[obj['key']] : cowc.D3_COLOR_CATEGORY5[1]
-                        };
-                        chartData.push(nodeMap[obj['key']]);
+                self.percentileConfigNodeNodeSummaryChart = function (chartModel) {
+                    var percentileSizeobjVal = getValueByJsonPath(chartModel, '0;PERCENTILES(api_stats.response_size);95', '-');
+                    var percentileTimeobjVal = getValueByJsonPath(chartModel, '0;PERCENTILES(api_stats.response_time_in_usec);95', '-');
+                    console.log(percentileTimeobjVal);
+                    var secs = percentileTimeobjVal / 1000;
+                    var seconds = Number((secs).toFixed(2))+' ms' // 6.7
+                    percentileTimeobjVal = seconds;
+                    var parsedData = [];
+                    var formatBytespercentileSizeVal = formatBytes(percentileSizeobjVal);
+                    parsedData.push({
+                        percentileXobjVal: percentileTimeobjVal,
+                        percentileYobjVal: formatBytespercentileSizeVal
                     });
-                    var lineChartData = {
-                        key: ctwl.RESPONSE_SIZE,
-                        values: [],
-                        color: monitorInfraConstants.CONFIGNODE_RESPONSESIZE_COLOR
-                    }
-                    for (var i in buckets) {
-                        var timestampExtent = buckets[i]['timestampExtent'],
-                            aggResSize = 0,
-                            avgResSize = 0,
-                            nodeReqMap = {};
-                        tsDim.filter(timestampExtent);
-                        var bucketRequestsCnt = tsDim.top(Infinity).length;
-                        sourceGroupedData = sourceDim.group().all();
-                        sourceGroupedData = _.sortBy(sourceGroupedData, 'key');
-                        $.each(sourceGroupedData, function(idx, obj) {
-                            nodeReqMap[obj['key']] = obj['value'];
-                        });
-                        var resTimeData = sourceDim.group().reduceSum(function (d) {
-                            return d['api_stats.response_time_in_usec'];
-                        });
-                        var resSizeData = sourceDim.group().reduceSum(function (d) {
-                            return d['api_stats.response_size'];
-                        });
-                        var resTimeArr = resTimeData.top(Infinity);
-                        var resSizeArr = resSizeData.top(Infinity);
-                        var resTimeArrLen = resTimeArr.length;
-                        var resSizeArrLen = resSizeArr.length;
-                        var resTimeNodeMap = {}, resSizeNodeMap = {};
-                        //Averaging the response time on node basis
-                        for (var j = 0; j < resTimeArrLen; j++) {
-                            if (nodeMap[resTimeArr[j]['key']] != null ) {
-                                var avgResTime = 0;
-                                avgResTime = resTimeArr[j]['value']/nodeReqMap[resTimeArr[j]['key']];
-                                avgResTime = avgResTime/1000; // converting to milli secs
-                                nodeMap[resTimeArr[j]['key']]['values'].push({
-                                    x: Math.round(i/1000),
-                                    y: avgResTime
-                                });
-                            }
-                        }
-                        //Calculating the aggregrate response size of all the nodes
-                        //in particular interval and averaging with overall requests
-                        //in the particular time interval.
-                        for (var j = 0; j < resSizeArrLen; j++) {
-                            aggResSize += resSizeArr[j]['value'];
-                        }
-                        avgResSize = aggResSize/bucketRequestsCnt;
-                        lineChartData['values'].push({
-                            x: Math.round(i/1000),
-                            y: avgResSize
-                        });
-                    }
-                    chartData.push(lineChartData);
-                    return chartData;
-
+                    return parsedData;
                 };
+                
                 this.parseConfigNodeRequestForDonutChart = function (apiStats, reqType, color) {
                     var cf = crossfilter(apiStats),
                         parsedData = [],

--- a/webroot/monitor/infrastructure/common/ui/js/views/ConfigNodeChartsView.js
+++ b/webroot/monitor/infrastructure/common/ui/js/views/ConfigNodeChartsView.js
@@ -3,119 +3,196 @@
  */
 
 define(['underscore', 'contrail-view', 'legend-view',
-        'monitor-infra-confignode-charts-model'],
-        function(_, ContrailView, LegendView, ConfigNodeChartsModel){
+        'monitor-infra-confignode-charts-model', 'monitor-infra-confignode-model'],
+        function(_, ContrailView, LegendView, ConfigNodeChartsModel, ConfigNodeListModel){
    var ConfigNodeChartView = ContrailView.extend({
         render : function (){
             var self = this,
                 viewConfig = self.attributes.viewConfig,
                 colorFn = viewConfig['colorFn'];
-            var chartModel = new ConfigNodeChartsModel();
-            self.renderView4Config(self.$el, chartModel,
-                    getConfigNodeChartViewConfig(colorFn));
+
+            self.$el.append($("<div class='gs-container'></div>"));
+            self.renderView4Config(self.$el.find('.gs-container'), null ,getGridStackWidgetConfig(colorFn));
         }
     });
 
-   function getConfigNodeChartViewConfig(colorFn) {
+   function getGridStackWidgetConfig(colorFn) {
+       var chartModel = new ConfigNodeChartsModel();
        return {
            elementId : ctwl.CONFIGNODE_SUMMARY_CHART_SECTION_ID,
            view : "SectionView",
            viewConfig : {
                rows : [ {
                    columns : [{
-                       elementId : ctwl.CONFIGNODE_SUMMARY_STACKEDCHART_ID,
-                       view : "StackedBarChartWithFocusView",
+                       elementId : 'confignode-gridstack-0',
+                       view : "GridStackView",
                        viewConfig : {
-                           class: 'col-xs-7 mon-infra-chart',
-                           chartOptions:{
-                               height: 480,
-                               xAxisLabel: '',
-                               yAxisLabel: 'Requests Served',
-                               title: ctwl.CONFIGNODE_SUMMARY_TITLE,
-                               groupBy: 'Source',
-                               failureCheckFn: function (d) {
-                                   if (parseInt(d['api_stats.resp_code']) != 200) {
-                                       return 1;
-                                   } else {
-                                       return 0;
-                                   }
-                               },
-                               yAxisOffset: 25,
-                               tickPadding: 8,
-                               margin: {
-                                   left: 40,
-                                   top: 20,
-                                   right: 0,
-                                   bottom: 40
-                               },
-                               bucketSize: monitorInfraConstants.STATS_BUCKET_DURATION,
-                               showControls: false,
-                               colors: colorFn
-                           }
-                       }
-                   },{
-                       elementId: ctwl.CONFIGNODE_SUMMARY_LINEBARCHART_ID,
-                       view: 'LineBarWithFocusChartView',
-                       viewConfig: {
-                           class: 'col-xs-5 mon-infra-chart',
-                           parseFn: function (response) {
-                               return monitorInfraParsers.parseConfigNodeResponseStackedChartData(response, colorFn);
+                           gridAttr: {
+                               defaultWidth: 6,
+                               defaultHeight: 10
                            },
-                           chartOptions: {
-                               y1AxisLabel:ctwl.RESPONSE_TIME,
-                               y2AxisLabel:ctwl.RESPONSE_SIZE,
-                               title: ctwl.CONFIGNODE_SUMMARY_TITLE,
-                               xAxisTicksCnt: 8, //In case of time scale for every 15 mins one tick
-                               margin: {top: 20, right: 50, bottom: 40, left: 50},
-                               axisLabelDistance: -10,
-                               y2AxisWidth: 50,
-                               //forceY1: [0, 1],
-                               focusEnable: false,
-                               height: 245,
-                               showLegend: true,
-                               xAxisLabel: '',
-                               //xAxisLabel: 'Time',
-                               xAxisMaxMin: false,
-                               defaultDataStatusMessage: false,
-                               xFormatter: function (xValue, tickCnt) {
-                                   // Same function is called for
-                                   // axis ticks and the tool tip
-                                   // title
-                                   var date = new Date(xValue);
-                                   if (tickCnt != null) {
-                                       var mins = date.getMinutes();
-                                       date.setMinutes(Math.ceil(mins/15) * 15);
+                           widgetCfgList: [{
+                               modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                   "table_name": "StatTable.VncApiStatsLog.api_stats",
+                                   "select": "PERCENTILES(api_stats.response_time_in_usec), PERCENTILES(api_stats.response_size)",
+                                   "parser": monitorInfraParsers.percentileConfigNodeNodeSummaryChart
+                               }),
+                               viewCfg: {
+                                   elementId : ctwl.CONFIGNODE_CHART_PERCENTILE_SECTION_ID,
+                                   view : "SectionView",
+                                   viewConfig : {
+                                       rows : [ {
+                                           columns : [ {
+                                               elementId :ctwl.CONFIGNODE_CHART_PERCENTILE_TEXT_VIEW,
+                                               title : '',
+                                               view : "PercentileTextView",
+                                               viewPathPrefix:
+                                                   ctwl.ANALYTICSNODE_VIEWPATH_PREFIX,
+                                               app : cowc.APP_CONTRAIL_CONTROLLER,
+                                               viewConfig : {
+                                                   percentileTitle : ctwl.CONFIGNODE_CHART_PERCENTILE_TITLE,
+                                                   percentileXvalue : ctwl.CONFIGNODE_CHART_PERCENTILE_TIME,
+                                                   percentileYvalue : ctwl.CONFIGNODE_CHART_PERCENTILE_SIZE,
+                                               }
+                                           }]
+                                       }]
                                    }
-                                   return d3.time.format('%H:%M')(date);
                                },
-                               y1Formatter: function (y1Value) {
-                                   var formattedValue = Math.round(y1Value) + ' ms';
-                                   if (y1Value > 1000){
-                                       // seconds block
-                                       formattedValue = Math.round(y1Value/1000);
-                                       formattedValue = formattedValue + ' secs'
-                                   } else if (y1Value > 60000) {
-                                       // minutes block
-                                       formattedValue = Math.round(y1Value/(60 * 1000))
-                                       formattedValue = formattedValue + ' mins'
+                               itemAttr: {
+                                   width: 2,
+                                   height:0.2
+                               }
+                           },{
+                                   modelCfg: chartModel,
+                                   viewCfg:
+                                       $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                           elementId : ctwl.CONFIGNODE_SUMMARY_STACKEDCHART_ID,
+                                           view: 'StackedAreaChartView',
+                                           viewConfig: {
+                                               class: 'col-xs-7 mon-infra-chart chartMargin',
+                                               chartOptions: {
+                                                   showControls: false,
+                                                   height: 480,
+                                                   colors: colorFn,
+                                                   title: ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                   xAxisLabel: '',
+                                                   yAxisLabel: 'Requests Served',
+                                                   groupBy: 'Source',
+                                                   failureCheckFn: function (d) {
+                                                       if (parseInt(d['api_stats.resp_code']) != 200) {
+                                                           return 1;
+                                                       } else {
+                                                           return 0;
+                                                       }
+                                                   },
+                                                   margin: {
+                                                       left: 40,
+                                                       top: 20,
+                                                       right: 0,
+                                                       bottom: 40
+                                                   }
+                                               }
+                                           }
+                                       }),
+                                   itemAttr: {
+                                       height: 2
                                    }
-                                   return formattedValue;
-                               },
-                               y2Formatter: function (y2Value) {
-                                   var formattedValue = formatBytes(y2Value, true);
-                                   return formattedValue;
-                               },
-                               legendView: LegendView
-                           },
-                       }
-                   }, {
-                       elementId: ctwl.CONFIGNODE_SUMMARY_DONUTCHART_SECTION_ID,
-                       view: 'ConfigNodeDonutChartView',
-                       viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
-                       app : cowc.APP_CONTRAIL_CONTROLLER,
-                       viewConfig: {
-                           class: 'col-xs-5 mon-infra-chart',
-                           color: colorFn
+                               },{
+                                   modelCfg: chartModel,
+                                   viewCfg: {
+                                       elementId: ctwl.CONFIGNODE_SUMMARY_LINEBARCHART_ID,
+                                       view: 'LineBarWithFocusChartView',
+                                       viewConfig: {
+                                           class: 'col-xs-5 mon-infra-chart',
+                                           parseFn: cowu.parseLineBarChartWithFocus,
+                                           chartOptions: {
+                                               y1AxisLabel:ctwl.RESPONSE_TIME,
+                                               y2AxisLabel:ctwl.RESPONSE_SIZE,
+                                               title: ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                               xAxisTicksCnt: 8, //In case of time scale for every 15 mins one tick
+                                               margin: {top: 20, right: 50, bottom: 40, left: 50},
+                                               axisLabelDistance: -10,
+                                               y2AxisWidth: 50,
+                                               focusEnable: false,
+                                               height: 245,
+                                               showLegend: true,
+                                               xAxisLabel: '',
+                                               xAxisMaxMin: false,
+                                               defaultDataStatusMessage: false,
+                                               insertEmptyBuckets: false,
+                                               bucketSize: 4,
+                                               groupBy: 'Source',
+                                               //Y1 for bar
+                                               y1Field: 'api_stats.response_time_in_usec',
+                                               //Y2 for line
+                                               y2Field: 'api_stats.response_size',
+                                               y2AxisColor: monitorInfraConstants.CONFIGNODE_RESPONSESIZE_COLOR,
+                                               y2FieldOperation: 'average',
+                                               y1FieldOperation: 'average',
+                                               colors: colorFn,
+                                               xFormatter: function (xValue, tickCnt) {
+                                                   // Same function is called for
+                                                   // axis ticks and the tool tip
+                                                   // title
+                                                   var date = new Date(xValue);
+                                                   if (tickCnt != null) {
+                                                       var mins = date.getMinutes();
+                                                       date.setMinutes(Math.ceil(mins/15) * 15);
+                                                   }
+                                                   return d3.time.format('%H:%M')(date);
+                                               },
+                                               y1Formatter: function (y1Value) {
+                                                   //Divide by 1000 to convert to milli secs;
+                                                   y1Value = ifNull(y1Value, 0)/1000;
+                                                   var formattedValue = Math.round(y1Value) + ' ms';
+                                                   if (y1Value > 1000){
+                                                       // seconds block
+                                                       formattedValue = Math.round(y1Value/1000);
+                                                       formattedValue = formattedValue + ' secs'
+                                                   } else if (y1Value > 60000) {
+                                                       // minutes block
+                                                       formattedValue = Math.round(y1Value/(60 * 1000))
+                                                       formattedValue = formattedValue + ' mins'
+                                                   }
+                                                   return formattedValue;
+                                               },
+                                               y2Formatter: function (y2Value) {
+                                                   var formattedValue = formatBytes(y2Value, true);
+                                                   return formattedValue;
+                                               },
+                                               legendView: LegendView,
+                                           },
+                                       }
+                                   },
+                               },{
+                                   modelCfg: chartModel,
+                                   viewCfg: {
+                                       elementId: ctwl.CONFIGNODE_SUMMARY_DONUTCHART_SECTION_ID,
+                                       view: 'ConfigNodeDonutChartView',
+                                       viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
+                                       app : cowc.APP_CONTRAIL_CONTROLLER,
+                                       viewConfig: {
+                                           class: 'col-xs-5 mon-infra-chart',
+                                           color: colorFn
+                                       }
+                                   }
+                               },{
+                                   modelCfg: new ConfigNodeListModel(),
+                                   viewCfg: {
+                                       title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                       view : "ConfigNodeSummaryGridView",
+                                       viewPathPrefix:
+                                           ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+                                       app : cowc.APP_CONTRAIL_CONTROLLER,
+                                       viewConfig : {
+                                           colorFn: colorFn
+                                       }
+                                   },
+                                   itemAttr: {
+                                       width: 2
+                                   }
+                               }
+                           ]
                        }
                    }]
                }]

--- a/webroot/monitor/infrastructure/common/ui/templates/monitor.infra.tmpl
+++ b/webroot/monitor/infrastructure/common/ui/templates/monitor.infra.tmpl
@@ -59,14 +59,14 @@
     </div>
 </script>
 <script type="text/x-handlebars-template" id="percentile-text-view-template">
-<div class="percentile row">
-    <label class="generator"><i class="fa fa-pie-chart"></i>95th Percentile - Messages (per min)</label>
+  <div class="percentile row">
+    <label class="generator"><i class="fa fa-pie-chart"></i>{{{this.percentileTitle}}}</label>
     <div class="pull-right">
-        <div class="value pull-left" >Count<span>{{{this.percentileMessagesobjVal}}}</span></div>
-        <div class="value pull-left">Size<span>{{{this.percentileSizeobjVal}}}</span></div>
+        <div class="value pull-left" >{{{this.percentileXvalue}}}<span>{{{this.percentileXobjVal}}}</span>&nbsp;&nbsp;&nbsp;|</div>
+        <div class="value pull-left">{{{this.percentileYvalue}}}<span>{{{this.percentileYobjVal}}}</span></div>
     </div>
     </div>
-</div>
+  </div>
 </script>
 <script type="text/x-handlebars-template" id="percentile-bar-view-template">
   <div class="percentile row">

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeListView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeListView.js
@@ -8,11 +8,10 @@ define(
                 _, ContrailView, ConfigNodeListModel, NodeColorMapping) {
             var ConfigNodeListView = ContrailView.extend({
                 render : function() {
-                    var configNodeListModel = new ConfigNodeListModel(),
-                        nodeColorMapping = new NodeColorMapping(),
+                    var nodeColorMapping = new NodeColorMapping(),
                         colorFn = nodeColorMapping.getNodeColorMap;
 
-                    this.renderView4Config(this.$el, configNodeListModel,
+                    this.renderView4Config(this.$el, null,
                             getConfigNodeListViewConfig(colorFn));
                 }
             });
@@ -22,32 +21,302 @@ define(
                 var viewConfig = {
                     rows : [
                          {
-                            columns : [ {
-                                elementId :
-                                    ctwl.CONFIGNODE_SUMMARY_CHART_ID,
-                                title : ctwl.CONFIGNODE_SUMMARY_TITLE,
-                                view : "ConfigNodeChartsView",
-                                viewPathPrefix:
-                                    ctwl.MONITOR_INFRA_VIEW_PATH,
-                                app : cowc.APP_CONTRAIL_CONTROLLER,
-                                viewConfig: {
-                                    colorFn: colorFn
-                                }
-                                    } ]
-                        },{
-                            columns : [ {
-                                elementId :
-                                    ctwl.CONFIGNODE_SUMMARY_GRID_ID,
-                                title : ctwl.CONFIGNODE_SUMMARY_TITLE,
-                                view : "ConfigNodeSummaryGridView",
-                                viewPathPrefix:
-                                    ctwl.CONFIGNODE_VIEWPATH_PREFIX,
-                                app : cowc.APP_CONTRAIL_CONTROLLER,
-                                viewConfig : {
-                                    colorFn: colorFn
-                                }
-                            } ]
-                        } ]
+                             columns : [
+                                        {
+                                 elementId: 'config-node-carousel-view',
+                                 view: "CarouselView",
+                                 viewConfig: {
+                                     pages : [
+                                          {
+                                              page: {
+                                                  elementId :ctwl.CONFIGNODE_SUMMARY_CHART_ID,
+                                                  title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                  view : "ConfigNodeChartsView",
+                                                  viewPathPrefix: ctwl.MONITOR_INFRA_VIEW_PATH,
+                                                  app : cowc.APP_CONTRAIL_CONTROLLER,
+                                                  viewConfig: {
+                                                      colorFn: colorFn
+                                                  }
+                                              },
+                                          },{
+                                              page: {
+                                                  elementId: 'grid-stack-view-page-1',
+                                                  view: 'GridStackView',
+                                                  viewConfig: {
+                                                      gridAttr: {
+                                                          defaultWidth: 6,
+                                                          defaultHeight: 10
+                                                      },
+                                                      widgetCfgList: [
+                                                            {
+                                                                modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                    table_name: 'StatTable.VncApiStatsLog.api_stats',
+                                                                    select: "T=, api_stats.useragent, COUNT(api_stats)"
+                                                                }),
+                                                                viewCfg: {
+                                                                    elementId : 'useragent_top_5_section',
+                                                                    view : "SectionView",
+                                                                    viewConfig : {
+                                                                        rows : [ {
+                                                                            columns :[
+                                                                                 $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                                                                     elementId : 'useragent_top_5',
+                                                                                     viewConfig: {
+                                                                                         chartOptions: {
+                                                                                             colors: cowc.FIVE_NODE_COLOR,
+                                                                                             title: 'User Agents',
+                                                                                             xAxisLabel: '',
+                                                                                             yAxisLabel: 'Top User Agents',
+                                                                                             groupBy: 'api_stats.useragent',
+                                                                                             limit: 5,
+                                                                                             yField: 'COUNT(api_stats)',
+                                                                                             margin: {
+                                                                                                 left: 40,
+                                                                                                 top: 20,
+                                                                                                 right: 0,
+                                                                                                 bottom: 40
+                                                                                             }
+                                                                                         }
+                                                                                     }
+                                                                                 })
+                                                                            ]
+                                                                        }]
+                                                                    }
+                                                                }
+                                                            },{
+                                                                modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                    table_name: 'StatTable.VncApiStatsLog.api_stats',
+                                                                    select: "T=, api_stats.object_type, COUNT(api_stats)"
+                                                                }),
+                                                                viewCfg: {
+                                                                    elementId : 'objecttype_top_5_section',
+                                                                    view : "SectionView",
+                                                                    viewConfig : {
+                                                                        rows : [ {
+                                                                            columns :[
+                                                                                 $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                                                                     elementId : 'objecttype_top_5',
+                                                                                     viewConfig: {
+                                                                                         chartOptions: {
+                                                                                             colors: cowc.FIVE_NODE_COLOR,
+                                                                                             title: 'Object Types',
+                                                                                             xAxisLabel: '',
+                                                                                             yAxisLabel: 'Top Object Types',
+                                                                                             groupBy: 'api_stats.object_type',
+                                                                                             limit: 5,
+                                                                                             yField: 'COUNT(api_stats)',
+                                                                                             margin: {
+                                                                                                 left: 40,
+                                                                                                 top: 20,
+                                                                                                 right: 0,
+                                                                                                 bottom: 40
+                                                                                             }
+                                                                                         }
+                                                                                     }
+                                                                                 })
+                                                                            ]
+                                                                        }]
+                                                                    }
+                                                                }
+                                                            }, {
+                                                                modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                    table_name: 'StatTable.VncApiStatsLog.api_stats',
+                                                                    select: "T=, api_stats.remote_ip, COUNT(api_stats)"
+                                                                }),
+                                                                viewCfg: {
+                                                                    elementId : 'remote_ip_top_5_section',
+                                                                    view : "SectionView",
+                                                                    viewConfig : {
+                                                                        rows : [ {
+                                                                            columns :[
+                                                                                 $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                                                                     elementId : 'remote_ip_top_5',
+                                                                                     viewConfig: {
+                                                                                         chartOptions: {
+                                                                                             colors: cowc.FIVE_NODE_COLOR,
+                                                                                             title: "Remote IPs",
+                                                                                             xAxisLabel: '',
+                                                                                             yAxisLabel: "Top Remote IPs",
+                                                                                             groupBy: 'api_stats.remote_ip',
+                                                                                             limit: 5,
+                                                                                             yField: 'COUNT(api_stats)',
+                                                                                             margin: {
+                                                                                                 left: 40,
+                                                                                                 top: 20,
+                                                                                                 right: 0,
+                                                                                                 bottom: 40
+                                                                                             }
+                                                                                         }
+                                                                                     }
+                                                                                 })
+                                                                            ]
+                                                                        }]
+                                                                    }
+                                                                }
+                                                            }, {
+                                                                modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                    table_name: 'StatTable.VncApiStatsLog.api_stats',
+                                                                    select: "T=, api_stats.project_name, COUNT(api_stats)"
+                                                                }),
+                                                                viewCfg: {
+                                                                    elementId : 'projects_top_5_section',
+                                                                    view : "SectionView",
+                                                                    viewConfig : {
+                                                                        rows : [ {
+                                                                            columns :[
+                                                                                 $.extend(true, {}, monitorInfraConstants.stackChartDefaultViewConfig, {
+                                                                                     elementId : 'projects_top_5',
+                                                                                     viewConfig: {
+                                                                                         chartOptions: {
+                                                                                             colors: cowc.FIVE_NODE_COLOR,
+                                                                                             title: "Projects",
+                                                                                             xAxisLabel: '',
+                                                                                             yAxisLabel: "Top Projects",
+                                                                                             groupBy: 'api_stats.project_name',
+                                                                                             limit: 5,
+                                                                                             yField: 'COUNT(api_stats)',
+                                                                                             margin: {
+                                                                                                 left: 40,
+                                                                                                 top: 20,
+                                                                                                 right: 0,
+                                                                                                 bottom: 40
+                                                                                             }
+                                                                                         }
+                                                                                     }
+                                                                                 })
+                                                                            ]
+                                                                        }]
+                                                                    }
+                                                                }
+                                                            }, {
+                                                                modelCfg: new ConfigNodeListModel(),
+                                                                viewCfg: {
+                                                                    title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                                    view : "ConfigNodeSummaryGridView",
+                                                                    viewPathPrefix:
+                                                                        ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+                                                                    app : cowc.APP_CONTRAIL_CONTROLLER,
+                                                                    viewConfig : {
+                                                                        colorFn: colorFn
+                                                                    }
+                                                                },
+                                                                itemAttr: {
+                                                                    width: 2
+                                                                }
+                                                            }
+                                                      ]
+                                                  }
+                                              }
+                                          },{
+                                              page: {
+                                                  elementId: 'grid-stack-view-page-2',
+                                                  view: 'GridStackView',
+                                                  viewConfig: {
+                                                      gridAttr: {
+                                                          defaultWidth: 6,
+                                                          defaultHeight: 10
+                                                      },
+                                                      widgetCfgList: [
+                                                          {
+                                                              modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                  table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                  select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                  where: 'process_mem_cpu_usage.__key = contrail-config-nodemgr'
+                                                              }),
+                                                              viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                  elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                  viewConfig: {
+                                                                      chartOptions: {
+                                                                          yFormatter: d3.format('.2f'),
+                                                                          yAxisLabel: 'Node Manager CPU Share (%)',
+                                                                          groupBy: 'name',
+                                                                          colors: colorFn,
+                                                                          yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                          title: ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                                      }
+                                                                  }
+                                                              })
+                                                          },{
+                                                              modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                  table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                  select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                  where: 'process_mem_cpu_usage.__key = contrail-schema'
+                                                              }),
+                                                              viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                  elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                  viewConfig: {
+                                                                      chartOptions: {
+                                                                          yFormatter: d3.format('.2f'),
+                                                                          yAxisLabel: 'Schema CPU Share (%)',
+                                                                          groupBy: 'name',
+                                                                          colors: colorFn,
+                                                                          yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                          title: ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                                      }
+                                                                  }
+                                                              })
+                                                          },{
+                                                              modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                  table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                  select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                  where: 'process_mem_cpu_usage.__key = contrail-discovery:0'
+                                                              }),
+                                                              viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                  elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                  viewConfig: {
+                                                                      chartOptions: {
+                                                                          yFormatter: d3.format('.2f'),
+                                                                          yAxisLabel: 'Discovery CPU Share (%)',
+                                                                          groupBy: 'name',
+                                                                          colors: colorFn,
+                                                                          yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                          title: ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                                      }
+                                                                  }
+                                                              })
+                                                          },{
+                                                              modelCfg: monitorInfraUtils.getStatsModelConfig({
+                                                                  table_name: 'StatTable.NodeStatus.process_mem_cpu_usage',
+                                                                  select: 'name, T=, MAX(process_mem_cpu_usage.cpu_share)',
+                                                                  where: 'process_mem_cpu_usage.__key = contrail-api:0'
+                                                              }),
+                                                              viewCfg: $.extend(true, {}, monitorInfraConstants.defaultLineChartViewCfg, {
+                                                                  elementId : ctwl.DATABASENODE_CPU_SHARE_LINE_CHART_ID,
+                                                                  viewConfig: {
+                                                                      chartOptions: {
+                                                                          yFormatter: d3.format('.2f'),
+                                                                          yAxisLabel: 'Api CPU Share (%)',
+                                                                          groupBy: 'name',
+                                                                          colors: colorFn,
+                                                                          yField: 'MAX(process_mem_cpu_usage.cpu_share)',
+                                                                          title: ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                                      }
+                                                                  }
+                                                              })
+                                                          },{
+                                                              modelCfg: new ConfigNodeListModel(),
+                                                              viewCfg: {
+                                                                  title : ctwl.CONFIGNODE_SUMMARY_TITLE,
+                                                                  view : "ConfigNodeSummaryGridView",
+                                                                  viewPathPrefix:
+                                                                      ctwl.CONFIGNODE_VIEWPATH_PREFIX,
+                                                                  app : cowc.APP_CONTRAIL_CONTROLLER,
+                                                                  viewConfig : {
+                                                                      colorFn: colorFn
+                                                                  }
+                                                              },
+                                                              itemAttr: {
+                                                                  width: 2
+                                                              }
+                                                          }
+                                                      ]
+                                                  }
+                                              }
+                                          }
+                                     ]
+                                 }
+                             }]
+                         }]
                 };
                 return {
                     elementId : cowu.formatElementId(

--- a/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeSummaryGridView.js
+++ b/webroot/monitor/infrastructure/confignode/ui/js/views/ConfigNodeSummaryGridView.js
@@ -146,7 +146,23 @@ define(
                        name:"Memory",
                        minWidth:150,
                        sortField:"y"
+                   },{
+                       field:"percentileResponse",
+                       id:"percentileTime",
+                       sortable:true,
+                       name:"95% - Responses",
+                       minWidth:200,
+                       formatter:function(r,c,v,cd,dc) {
+                           return '<span><b>'+"Time "+
+                                   '</b></span>' +
+                                  '<span class="display-inline">' +
+                                  (dc['percentileTime']) + '</span>'+'<span><b>'+", Size "+
+                                   '</b></span>' +
+                                  '<span class="display-inline">' +
+                                  (dc['percentileSize']) + '</span>';
+                       }
                    }
+
                 ];
                 var gridElementConfig = {
                     header : {


### PR DESCRIPTION
Integrated gridstack and carousel changes in config node and analytics node summary charts,
Currently we added charts on Top N parameters(Eg: Top user agents in config node, Top message type in analytics node)
and different processes CPU usage(Eg: alarm-gen, qe in analytics node, ifMap in config node)

On behalf of akhil
Added the percentile per node in config and analytics node grids.

Change-Id: I8a6f9bbc032642d46583333615c409889de7cd7c